### PR TITLE
Escape build path when compressing app.zip on Mac

### DIFF
--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -52,7 +52,7 @@ class CompressApplication
      */
     protected function compressApplicationOnMac()
     {
-        (new Process('zip -r '.$this->buildPath.'/app.zip .', $this->appPath))->mustRun();
+        (new Process(['zip', '-r', $this->buildPath.'/app.zip', '.'], $this->appPath))->mustRun();
     }
 
     /**


### PR DESCRIPTION
`CompressApplication` will fail to create the app.zip file if your build path contains a space in it. Instead of passing the entire command to `Process` as a string, we can pass each segment as an array to allow `Process` to escape the arguments for us.

Before this change, running `vapor deploy staging` on a fresh install fails. After this change it runs just fine.