### PR TITLE
Provide correct DB_CONNECTION env var for local commands

### DIFF
--- a/src/Commands/LocalCommand.php
+++ b/src/Commands/LocalCommand.php
@@ -66,6 +66,7 @@ class LocalCommand extends Command
                 $dockerComposePath,
                 'run',
                 '--rm',
+                '-e DB_CONNECTION=mysql',
                 '-e DB_HOST=mysql',
                 '-e DB_DATABASE=vapor',
                 '-e DB_PORT=3306',


### PR DESCRIPTION
This PR makes sure that when the `vapor local` command provides `DB_` env vars to Docker, that `DB_CONNECTION` is also provided.

The reason for this is that in my local `.env` files I had `DB_CONNECTION` configured as `sqlite`, so when running `vapor local` or `vapor test` it would try to find an sqlite database called `vapor`.

I should note that I haven't been able to verify that this actually works, because when I specify `DB_CONNECTION=mysql` I am still unable to get local commands/testing working due to `PDOException: could not find driver`, which seems strange as I would imagine that the Vapor Docker image has the php mysql extension installed. But I think that's a separate issue and I haven't ruled out a problem on my end yet.