### PR TITLE
$_SERVER['HOME'] is not defined on Windows, $_SERVER['APPDATA'] is equivalent

### DIFF
--- a/src/Commands/CacheTunnelCommand.php
+++ b/src/Commands/CacheTunnelCommand.php
@@ -82,7 +82,7 @@ class CacheTunnelCommand extends Command
     protected function storeJumpBoxKey(array $jumpBox)
     {
         file_put_contents(
-            $path = $_SERVER['HOME'].'/.ssh/vapor-cache-tunnel',
+            $path = $_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.ssh/vapor-cache-tunnel',
             $this->vapor->jumpBoxKey($jumpBox['id'])['private_key']
         );
 

--- a/src/Commands/DatabaseShellCommand.php
+++ b/src/Commands/DatabaseShellCommand.php
@@ -112,7 +112,7 @@ class DatabaseShellCommand extends Command
     protected function storeJumpBoxKey(array $jumpBox)
     {
         file_put_contents(
-            $path = $_SERVER['HOME'].'/.ssh/vapor-database-shell',
+            $path = $_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.ssh/vapor-database-shell',
             $this->vapor->jumpBoxKey($jumpBox['id'])['private_key']
         );
 

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -63,9 +63,9 @@ class JumpCommand extends Command
      */
     protected function storePrivateKey($name, $privateKey)
     {
-        if (is_dir($_SERVER['HOME'].'/.ssh') &&
+        if (is_dir($_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.ssh') &&
             Helpers::confirm('Would you like to store the private key in your ~/.ssh directory', true)) {
-            file_put_contents($path = $_SERVER['HOME'].'/.ssh/vapor-jump-'.$name, $privateKey);
+            file_put_contents($path = $_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.ssh/vapor-jump-'.$name, $privateKey);
 
             chmod($path, 0600);
 

--- a/src/Commands/JumpDeleteCommand.php
+++ b/src/Commands/JumpDeleteCommand.php
@@ -41,7 +41,7 @@ class JumpDeleteCommand extends Command
 
         Helpers::info('Jumpbox deleted successfully.');
 
-        if (file_exists($path = $_SERVER['HOME'].'/.ssh/vapor-jump-'.$jumpBoxName)) {
+        if (file_exists($path = $_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.ssh/vapor-jump-'.$jumpBoxName)) {
             @unlink($path);
         }
     }

--- a/src/Commands/RetrievesProviderCredentials.php
+++ b/src/Commands/RetrievesProviderCredentials.php
@@ -13,7 +13,7 @@ trait RetrievesProviderCredentials
      */
     protected function getAWSCredentials()
     {
-        if (file_exists($_SERVER['HOME'].'/.aws/credentials') &&
+        if (file_exists($_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.aws/credentials') &&
             Helpers::confirm('Would you like to choose credentials from your AWS credentials file', true)) {
             return $this->getCredentialsFromFile();
         }
@@ -32,7 +32,7 @@ trait RetrievesProviderCredentials
     protected function getCredentialsFromFile()
     {
         $credential = $this->determineCredential(
-            $credentials = parse_ini_file($_SERVER['HOME'].'/.aws/credentials', true)
+            $credentials = parse_ini_file($_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.aws/credentials', true)
         );
 
         return [

--- a/src/Config.php
+++ b/src/Config.php
@@ -59,6 +59,6 @@ class Config
      */
     protected static function path()
     {
-        return $_SERVER['HOME'].'/.laravel-vapor/config.json';
+        return $_SERVER['HOME'] ?? $_SERVER['APPDATA'].'/.laravel-vapor/config.json';
     }
 }


### PR DESCRIPTION
Hi there.

I couldn't raise an issue regarding Windows support, and there doesn't appear to be a process on contributing at the moment.

This adds basic Windows support, but there is still more to be done.
There shouldn't be any breaking changes in this pull request.

Essentially, this replaces uses of `$_SERVER['HOME']` with `$_SERVER['HOME'] ?? $_SERVER['APPDATA']`.

Without this change, it's impossible to even proceed through the `vapor login` command.

Please let me know if there is a better way of contributing.