### PR TITLE
Change vapor-core check to look in build directory

### DIFF
--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -19,7 +19,7 @@ class InjectHandlers
     {
         Helpers::step('<bright>Injecting Serverless Handlers</>');
 
-        if (! is_dir(getcwd().'/vendor/laravel/vapor-core')) {
+        if (! is_dir($this->appPath.'/vendor/laravel/vapor-core')) {
             Helpers::abort('Unable to find laravel/vapor-core installation.');
         }
 


### PR DESCRIPTION
Because this check happens AFTER the build script, and all the files have already been copied to the build folder, changing this check to look for the directory that the files are being copied from, instead of the project root,  gives users the option to cut out an unnecessary "composer install" in their pipelines and maybe cut down on build times.

For example:
I use Chipper for running my unit tests.
But I use Bitbucket pipelines to deploy after the merge.

Even though I run composer install in my vapor deploy build script, I still have to run composer install on my project root for this single file check.

This change would allow for the composer install on the project root to be eliminated for pipelines that are using 3rd party CI. Cutting down on deployment time.