### PR TITLE
Fix to invalid .env file

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -55,7 +55,7 @@ class SetBuildEnvironment
 
         // Mix takes the last environment variable value...
         $this->files->append(
-            $envPath, 'APP_ENV='.$this->environment.PHP_EOL
+            $envPath, PHP_EOL.'APP_ENV='.$this->environment.PHP_EOL
         );
 
         $this->files->append(


### PR DESCRIPTION
fix to: 
The environment file is invalid!                                                                              
Failed to parse dotenv file due to unexpected whitespace.