### PR TITLE
Windows - Fix relative paths in app.zip

### DIFF
--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -31,10 +31,12 @@ class CompressApplication
         $archive->open($this->buildPath.'/app.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
 
         foreach (BuiltApplicationFiles::get($this->appPath) as $file) {
-            $archive->addFile($file->getRealPath(), $file->getRelativePathname());
+            $relativePathName = str_replace("\\","/", $file->getRelativePathname());
+
+            $archive->addFile($file->getRealPath(), $relativePathName);
 
             $archive->setExternalAttributesName(
-                $file->getRelativePathname(),
+                $relativePathName,
                 ZipArchive::OPSYS_UNIX,
                 ($this->getPermissions($file) & 0xffff) << 16
             );

--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -31,7 +31,7 @@ class CompressApplication
         $archive->open($this->buildPath.'/app.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
 
         foreach (BuiltApplicationFiles::get($this->appPath) as $file) {
-            $relativePathName = str_replace("\\","/", $file->getRelativePathname());
+            $relativePathName = str_replace("\\", "/", $file->getRelativePathname());
 
             $archive->addFile($file->getRealPath(), $relativePathName);
 

--- a/src/BuildProcess/CompressVendor.php
+++ b/src/BuildProcess/CompressVendor.php
@@ -34,10 +34,12 @@ class CompressVendor
         $archive->open($this->buildPath.'/vendor.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
 
         foreach (BuiltApplicationFiles::get($this->vendorPath) as $file) {
-            $archive->addFile($file->getRealPath(), $file->getRelativePathname());
+            $relativePathName = str_replace("\\","/", $file->getRelativePathname());
+
+            $archive->addFile($file->getRealPath(), $relativePathName);
 
             $archive->setExternalAttributesName(
-                $file->getRelativePathname(),
+                $relativePathName,
                 ZipArchive::OPSYS_UNIX,
                 ($this->getPermissions($file) & 0xffff) << 16
             );

--- a/src/BuildProcess/CompressVendor.php
+++ b/src/BuildProcess/CompressVendor.php
@@ -34,7 +34,7 @@ class CompressVendor
         $archive->open($this->buildPath.'/vendor.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
 
         foreach (BuiltApplicationFiles::get($this->vendorPath) as $file) {
-            $relativePathName = str_replace("\\","/", $file->getRelativePathname());
+            $relativePathName = str_replace("\\", "/", $file->getRelativePathname());
 
             $archive->addFile($file->getRealPath(), $relativePathName);
 


### PR DESCRIPTION
After changes by @chrishardinge and I believe yourselves on the Vapor Core 2.0 branch (exposing PHP Error's) I started receiving PHP/Composer errors within AWS deployments from Windows.

The runtime/app is unable to load the composer dependencies, I'm assuming as it extracts the files incorrectly due to their relative paths being different/invalid for Linux when compiled/zipped under Windows as seen below -

Windows app.zip

```
~/vapor-test/vapor-test$ zipinfo windows.zip "*autoload*"                                                                                                                 -r--r--r--  6.3 unx      178 b- defX 19-Sep-16 16:31 vendor\autoload.php
-r--r--r--  6.3 unx   408342 b- defX 19-Sep-16 16:31 vendor\composer\autoload_classmap.php
-r--r--r--  6.3 unx     2984 b- defX 19-Sep-16 16:31 vendor\composer\autoload_files.php
-r--r--r--  6.3 unx      278 b- defX 19-Sep-16 16:31 vendor\composer\autoload_namespaces.php
-r--r--r--  6.3 unx     4887 b- defX 19-Sep-16 16:31 vendor\composer\autoload_psr4.php
-r--r--r--  6.3 unx     2103 b- defX 19-Sep-16 16:31 vendor\composer\autoload_real.php
-r--r--r--  6.3 unx   452425 b- defX 19-Sep-16 16:31 vendor\composer\autoload_static.php
-r--r--r--  6.3 unx     1001 b- defX 19-Sep-16 16:31 vendor\opis\closure\autoload.php
-r--r--r--  6.3 unx      231 b- defX 19-Sep-16 16:31 vendor\paragonie\random_compat\psalm-autoload.php
```

WSL app.zip

```
~/vapor-test/vapor-test$ zipinfo wsl.zip "*autoload*"                                                                                                                     -r--r--r--  6.3 unx     1001 b- defX 19-Sep-16 17:00 vendor/opis/closure/autoload.php
-r--r--r--  6.3 unx      178 b- defX 19-Sep-16 17:00 vendor/autoload.php
-r--r--r--  6.3 unx     2984 b- defX 19-Sep-16 17:00 vendor/composer/autoload_files.php
-r--r--r--  6.3 unx     2103 b- defX 19-Sep-16 17:00 vendor/composer/autoload_real.php
-r--r--r--  6.3 unx   408342 b- defX 19-Sep-16 17:00 vendor/composer/autoload_classmap.php
-r--r--r--  6.3 unx   452425 b- defX 19-Sep-16 17:00 vendor/composer/autoload_static.php
-r--r--r--  6.3 unx     4887 b- defX 19-Sep-16 17:00 vendor/composer/autoload_psr4.php
-r--r--r--  6.3 unx      278 b- defX 19-Sep-16 17:00 vendor/composer/autoload_namespaces.php
-r--r--r--  6.3 unx      231 b- defX 19-Sep-16 17:00 vendor/paragonie/random_compat/psalm-autoload.php
```

@chrishardinge - Hopefully you can check this over and confirm it works for yourself under windows as well. However for myself, the attached changes allow me to run vapor deployments under windows - https://windows.simonrigby.dev/ , I'm no longer receiving a 502 Gateway Timeout error when visiting the page, both using the domain and vanity url.