### PR TITLE
Show more details when an authentication fails

### DIFF
--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -36,9 +36,7 @@ class ConsoleVaporClient
                 }
             }
 
-            return false;
-        } catch (Exception $e) {
-            return false;
+            throw $e;
         }
     }
 
@@ -1345,7 +1343,7 @@ class ConsoleVaporClient
     protected function client()
     {
         return new Client([
-           'base_uri' => $_ENV['VAPOR_API_BASE'] ?? 'https://vapor.laravel.com',
+            'base_uri' => $_ENV['VAPOR_API_BASE'] ?? getenv('VAPOR_API_BASE') ?: 'https://vapor.laravel.com',
            // 'base_uri' => $_ENV['VAPOR_API_BASE'] ?? 'https://laravel-vapor.ngrok.io',
         ]);
     }


### PR DESCRIPTION
Some people report authentication failure even though the provide the correct credentials, this PR will show more information in case of failure to help people debug.