### PR TITLE
Ability to ignore directories

### DIFF
--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -27,7 +27,6 @@ class RemoveIgnoredFiles
         $this->removeSymfonyTests();
 
         $this->removeUserIgnoredFiles();
-        $this->removeSpecialDirectories();
     }
 
     /**
@@ -99,27 +98,6 @@ class RemoveIgnoredFiles
             }
         }
     }
-
-
-  /**
-   * Remove the directories that are ignored by default.
-   *
-   * @return void
-   */
-  protected function removeSpecialDirectories()
-  {
-        $defaultDirectories = [
-              Path::app().'/compose',
-              Path::app().'/vendor/backpack/crud/src/public/packages',
-        ];
-
-        foreach ($defaultDirectories as $directory) {
-              if ($this->files->isDirectory($directory)) {
-                    $this->files->deleteDirectory($directory, $preserve = true);
-              }
-        }
-  }
-
 
   /**
      * Remove the tests from the Symfony components.

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -27,6 +27,7 @@ class RemoveIgnoredFiles
         $this->removeSymfonyTests();
 
         $this->removeUserIgnoredFiles();
+        $this->removeSpecialDirectories();
     }
 
     /**
@@ -99,7 +100,28 @@ class RemoveIgnoredFiles
         }
     }
 
-    /**
+
+  /**
+   * Remove the directories that are ignored by default.
+   *
+   * @return void
+   */
+  protected function removeSpecialDirectories()
+  {
+        $defaultDirectories = [
+              Path::app().'/compose',
+              Path::app().'/vendor/backpack/crud/src/public/packages',
+        ];
+
+        foreach ($defaultDirectories as $directory) {
+              if ($this->files->isDirectory($directory)) {
+                    $this->files->deleteDirectory($directory, $preserve = true);
+              }
+        }
+  }
+
+
+  /**
      * Remove the tests from the Symfony components.
      *
      * @return void

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -145,16 +145,20 @@ class RemoveIgnoredFiles
         foreach (Manifest::ignoredFiles() as $pattern) {
             [$directory, $filePattern] = $this->parsePattern($pattern);
 
-            $files = (new Finder)
-                        ->in($directory)
-                        ->depth('== 0')
-                        ->ignoreDotFiles(false)
-                        ->name($filePattern);
+            if ($this->files->exists($directory.'/'.$filePattern) && $this->files->isDirectory($directory.'/'.$filePattern)) {
+                $this->files->deleteDirectory($directory.'/'.$filePattern, $preserve = false);
+            } else {
+                $files = (new Finder)
+                            ->in($directory)
+                            ->depth('== 0')
+                            ->ignoreDotFiles(false)
+                            ->name($filePattern);
 
-            foreach ($files as $file) {
-                Helpers::step('<comment>Removing Ignored File:</comment> '.str_replace(Path::app().'/', '', $file->getRealPath()));
+                foreach ($files as $file) {
+                    Helpers::step('<comment>Removing Ignored File:</comment> '.str_replace(Path::app().'/', '', $file->getRealPath()));
 
-                $this->files->delete($file->getRealPath());
+                    $this->files->delete($file->getRealPath());
+                }
             }
         }
     }


### PR DESCRIPTION
Vapor CLI provides a way to ignore files, but not directories. 

There are many situations in which ignoring directories are useful. (Logs, build artifacts, docker stuff, etc) 

Laravel Backpack (https://github.com/Laravel-Backpack/CRUD) for example comes with a lot of various JavaScript packages that take up a considerable amount of space. 

This package already ignores some directories as well... https://github.com/laravel/vapor-cli/blob/master/src/BuildProcess/RemoveIgnoredFiles.php#L74-L100

This PR simply checks if the ignore pattern is a directory and if it is, deletes it. If it's not a directory it flows into the previous file deletion logic. 