### PR TITLE
Add name, provider, and region options to init command.

### DIFF
--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Str;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Manifest;
 use Laravel\VaporCli\GitIgnore;
+use Symfony\Component\Console\Input\InputOption;
 
 class InitCommand extends Command
 {
@@ -19,6 +20,9 @@ class InitCommand extends Command
     {
         $this
             ->setName('init')
+            ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The name of this project')
+            ->addOption('provider', null, InputOption::VALUE_OPTIONAL, 'The cloud provider that the project should belong to')
+            ->addOption('region', null, InputOption::VALUE_OPTIONAL, 'The region that the project should be placed in')
             ->setDescription('Initialize a new project in the current directory');
     }
 
@@ -77,6 +81,10 @@ class InitCommand extends Command
      */
     protected function determineName()
     {
+        if($this->option('name')) {
+            return Str::slug($this->option('name'));
+        }
+
         return Str::slug(Helpers::ask(
             'What is the name of this project', basename(Path::current())
         ));

--- a/src/Commands/ProvidesSelectionMenus.php
+++ b/src/Commands/ProvidesSelectionMenus.php
@@ -95,6 +95,10 @@ trait ProvidesSelectionMenus
      */
     protected function determineRegion($message)
     {
+        if ($this->input->hasOption('region') && $this->option('region')) {
+            return $this->option('region');
+        }
+
         return $this->menu($message, Regions::available());
     }
 }


### PR DESCRIPTION
This addition is useful for automating the initialisation of projects in environments where interactive questions cannot be answered.

`vapor init --no-interaction --name project-name --region us-east-1`