### PR TITLE
Update Composer command causing issues with separate vendor directory

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -93,7 +93,7 @@ class Manifest
                     'memory' => 1024,
                     'cli-memory' => 512,
                     'build' => [
-                        'composer install --no-dev --classmap-authoritative',
+                        'composer install --no-dev',
                         'php artisan event:cache',
                         'npm ci && npm run prod && rm -rf node_modules',
                     ],
@@ -102,7 +102,7 @@ class Manifest
                     'memory' => 1024,
                     'cli-memory' => 512,
                     'build' => [
-                        'composer install --classmap-authoritative',
+                        'composer install',
                         'php artisan event:cache',
                         'npm ci && npm run dev && rm -rf node_modules',
                     ],
@@ -127,7 +127,7 @@ class Manifest
         }
 
         $manifest['environments'][$environment] = ! empty($config) ? $config : [
-            'build' => ['composer install --no-dev --classmap-authoritative']
+            'build' => ['composer install --no-dev']
         ];
 
         $manifest['environments'] = collect(


### PR DESCRIPTION
I'm not exactly sure how this should be handled, but I wanted to propose this fix as it's caused us several headaches while trying to figure out why we were unable to add new classes when using separate-vendor without updating Composer dependencies to force update our vendor directory.

Due to separate-vendor not updating the autoload classmaps for Composer on each deploy, any time that new classes are added, Composer is unable to find them using PSR-4 due to this classmap-authoritative argument. In the Composer docs for this argument (https://getcomposer.org/doc/articles/autoloader-optimization.md#optimization-level-2-a-authoritative-class-maps), it specifically states that "This option is very simple, it says that if something is not found in the classmap, then it does not exist and the autoloader should not attempt to look on the filesystem according to PSR-4 rules".

I'm not exactly sure why Vapor is using this argument as the default, and if it's necessary in some cases I can submit a PR to the Vapor docs instead adding a notice about incompatibilities when using the separate-vendor option.