### PR TITLE
Check for envrionment-specific .env file

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -45,7 +45,7 @@ class SetBuildEnvironment
     {
         Helpers::step('<bright>Setting Build Environment</>');
 
-        if (! file_exists($envPath = $this->appPath.'/.env')) {
+        if (! file_exists($envPath = $this->appPath.'/.env.'.$this->environment) && ! file_exists($envPath = $this->appPath.'/.env')) {
             return;
         }
 

--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -45,7 +45,8 @@ class SetBuildEnvironment
     {
         Helpers::step('<bright>Setting Build Environment</>');
 
-        if (! file_exists($envPath = $this->appPath.'/.env.'.$this->environment) && ! file_exists($envPath = $this->appPath.'/.env')) {
+        if (! file_exists($envPath = $this->appPath.'/.env.'.$this->environment) && 
+            ! file_exists($envPath = $this->appPath.'/.env')) {
             return;
         }
 


### PR DESCRIPTION
Keep parity with `vapor env:pull` which outputs to [`.env.{environment}`](https://docs.vapor.build/1.0/projects/environments.html#environment-variables). Ideally, there should be an option to pull the environment variables from the staging environment and use those for the build rather than relying on having an `.env` file. (I haven't seen that this is an option.)