### PR TITLE
Add the ability to retrieve a zone by id

### DIFF
--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -207,6 +207,17 @@ class ConsoleVaporClient
     {
         return $this->request('get', '/api/teams/'.Helpers::config('team').'/zones');
     }
+    
+    /**
+     * Get the zone with the given ID.
+     *
+     * @param  string  $zoneId
+     * @return array
+     */
+    public function zone($zoneId)
+    {
+        return $this->request('get', '/api/zones/'.$zoneId);
+    }
 
     /**
      * Create a new zone.


### PR DESCRIPTION
Fetch an existing zone by ID.

This exists in the Vapor interface itself and is very useful for things such as the importing boolean. Why? Because you can't create the certificate until the domain is done importing, it seems, which makes sense.