### PR TITLE
Create .env if not exists

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -45,9 +45,8 @@ class SetBuildEnvironment
     {
         Helpers::step('<bright>Setting Build Environment</>');
 
-        if (! file_exists($envPath = $this->appPath.'/.env.'.$this->environment) && 
-            ! file_exists($envPath = $this->appPath.'/.env')) {
-            return;
+        if (! file_exists($envPath = $this->appPath.'/.env.'.$this->environment)) {
+            $envPath = $this->appPath.'/.env';
         }
 
         $this->files->prepend(


### PR DESCRIPTION
Currently if .env does not exists the mix process will point the assets to the local server.

This pull request fixes this by creating it if not exists.