### PR TITLE
Fix timestamps in tail command

### DIFF
--- a/src/Commands/TailCommand.php
+++ b/src/Commands/TailCommand.php
@@ -166,7 +166,7 @@ class TailCommand extends Command
 
         $this->output->writeln(sprintf(
             '[<fg=magenta>%s</>] [<comment>%s</comment>]: %s',
-            $this->formatDate($message['datetime']['date']),
+            $this->formatDate($message['datetime']),
             $level,
             $this->formatMessage($message['message'])
         ));


### PR DESCRIPTION
Inspecting the payload of the `tail` endpoint the timestamps are being sent as strings instead of arrays.

This prevents the `Illegal string offset 'date' in ...TailCommand.php` error while executing the `vapor tail` command.

Maybe the timestamps are being serialized differently in the api endpoint?