### PR TITLE
Use the correct .env file when building

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -44,7 +44,7 @@ class SetBuildEnvironment
     {
         Helpers::step('<bright>Setting Build Environment</>');
 
-        if (! file_exists($envPath = $this->appPath.'/.env')) {
+        if (! file_exists($envPath = $this->appPath.'/.env.'.$this->environment)) {
             return;
         }
 


### PR DESCRIPTION
Right now it injects variables into `.env` instead of `.env.production` etc.