### PR TITLE
Use environment-specific .env file

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -48,6 +48,15 @@ class SetBuildEnvironment
             return;
         }
 
+        if (file_exists($this->appPath.'/.env.'.$this->environment)) {
+            $this->files->copy(
+                $this->appPath.'/.env.'.$this->environment,
+                $envPath
+            );
+
+            $this->files->delete($this->appPath.'/.env.'.$this->environment);
+        }
+
         $this->files->prepend(
             $envPath, 'APP_ENV='.$this->environment.PHP_EOL
         );


### PR DESCRIPTION
While running the build commands, having an environment specific .env file will be used by Laravel. However, Mix will only look into the `.env` file.

This PR does the following:

- Checks if we have an environment specific .env file.
- Replace the existing .env file with the environment specific one.
- Delete the the environment specific one.

Now both Laravel and Mix will find a single .env file to read from.