### PR TITLE
Keep json asset files in deployment artifact

### DIFF
--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -24,7 +24,7 @@ class AssetFiles
                 ->exclude('storage')
                 ->notName('.htaccess')
                 ->notName('web.config')
-                ->notName('mix-manifest.json')
+                ->notName('*.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
                 ->ignoreDotFiles(true)


### PR DESCRIPTION
Livewire looks for a `manifest.json` file to check if its JS assets are published and current ([reference](https://github.com/livewire/livewire/blob/55c8a5d632a895672204dc997d6ee42b07b61284/src/LivewireManager.php#L245)). I've loosened the strictness of which files should be kept in the `/public` path to include all `*.json` files rather than just `mix-manifest.json`.

Json files are typically only a few bytes in size, however, you'd prefer it to be a bit more specific, I can update to include only `*manifest.json` files.

If this solution is not ideal or too specific, would a `include:` key in the manifest be considered?