### PR TITLE
Copy application files and preserve permissions

### DIFF
--- a/src/BuildProcess/CopyApplicationToBuildPath.php
+++ b/src/BuildProcess/CopyApplicationToBuildPath.php
@@ -58,6 +58,11 @@ class CopyApplicationToBuildPath
             $file->getRealPath(),
             $this->appPath.'/'.$file->getRelativePathname()
         );
+
+        $this->files->chmod(
+            $this->appPath.'/'.$file->getRelativePathname(),
+            fileperms($file->getRealPath())
+        );
     }
 
     /**


### PR DESCRIPTION
This keeps executables inside the vendor directory runnable inside the lambda.