### PR TITLE
Preserve vendor file permissions

### DIFF
--- a/src/BuildProcess/CompressVendor.php
+++ b/src/BuildProcess/CompressVendor.php
@@ -68,6 +68,6 @@ class CompressVendor
     {
         return $file->isDir() || $file->getFilename() == 'php'
                         ? 33133  // '-r-xr-xr-x'
-                        : 33060; // '-r--r--r--'
+                        : fileperms($file->getRealPath());
     }
 }

--- a/src/BuildProcess/ExtractVendorToSeparateDirectory.php
+++ b/src/BuildProcess/ExtractVendorToSeparateDirectory.php
@@ -25,12 +25,10 @@ class ExtractVendorToSeparateDirectory
 
         $this->ensureVendorDirectoryExists();
 
-        (new Filesystem)->copyDirectory(
+        (new Filesystem)->move(
             $this->appPath.'/vendor',
             $this->buildPath.'/vendor'
         );
-
-        $this->files->deleteDirectory($this->appPath.'/vendor');
     }
 
     /**


### PR DESCRIPTION
This PR resolves an issue where executables within the vendor directory will lose their execute permissions during the 'Extracting Vendor Files' and 'Compressing Vendor Directory' steps of the build process.