### PR TITLE
Create an empty .env when it is missing

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -45,7 +45,8 @@ class SetBuildEnvironment
         Helpers::step('<bright>Setting Build Environment</>');
 
         if (! file_exists($envPath = $this->appPath.'/.env')) {
-            return;
+            // create an empty .env
+            $this->files->put($envPath, '');
         }
 
         if (file_exists($this->appPath.'/.env.'.$this->environment)) {
@@ -58,16 +59,19 @@ class SetBuildEnvironment
         }
 
         $this->files->prepend(
-            $envPath, 'APP_ENV='.$this->environment.PHP_EOL
+            $envPath,
+            'APP_ENV='.$this->environment.PHP_EOL
         );
 
         // Mix takes the last environment variable value...
         $this->files->append(
-            $envPath, PHP_EOL.'APP_ENV='.$this->environment.PHP_EOL
+            $envPath,
+            PHP_EOL.'APP_ENV='.$this->environment.PHP_EOL
         );
 
         $this->files->append(
-            $envPath, 'ASSET_URL='.$this->assetUrl.PHP_EOL
+            $envPath,
+            'ASSET_URL='.$this->assetUrl.PHP_EOL
         );
     }
 }


### PR DESCRIPTION
Currently, when Vapor CLI detects that no `.env`file is present, it will silently ignore all the build en steps.

This is causing strange behaviour. For example, see [this Laracasts forum thread](https://laracasts.com/discuss/channels/vapor/why-doesnt-laravel-vapor-inject-asset-url-in-my-build-step).

The solution to this issue is fairly simple: just create an empty `.env` file, so the file exists and the CLI can inject its variables.