### PR TITLE
Add autoload_real.php to the vendor hash

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -238,7 +238,7 @@ class DeployCommand extends Command
      */
     protected function createVendorHash()
     {
-        return md5(md5_file(Path::app().'/composer.json').md5_file(Path::app().'/composer.lock'));
+        return md5(md5_file(Path::app().'/composer.json').md5_file(Path::app().'/composer.lock').md5_file(Path::vendor().'/composer/autoload_real.php'));
     }
 
     /**


### PR DESCRIPTION
This will make it easier for people to remove `--classmap-authoritative` from their build commands and upload the new vendor directory after the change.