### PR TITLE
Support symfony/yaml version 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/console": "^4.2|^5.0",
         "symfony/process": "^4.2|^5.0",
         "symfony/var-dumper": "^4.2|^5.0",
-        "symfony/yaml": "^4.2",
+        "symfony/yaml": "^4.2|^5.0",
         "vlucas/phpdotenv": "^3.0|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Since most Laravel packages are locking min req of Symfony packages to v5, then we need to be able to use `symfony/yaml` v5. 

As seen below, we cannot require Vapor-Cli package due to this. 

```
$ composer require laravel/vapor-cli --dev
Using version ^1.6 for laravel/vapor-cli
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove symfony/dependency-injection v5.0.5
    - Conclusion: don't install symfony/dependency-injection v5.0.5
    - symfony/yaml 4.2.x-dev conflicts with symfony/dependency-injection[v5.0.5].
    - symfony/yaml 4.3.x-dev conflicts with symfony/dependency-injection[v5.0.5].
    - symfony/yaml v4.2.0 conflicts with symfony/dependency-injection[v5.0.5].
    ...
```

See https://github.com/symfony/dependency-injection/blob/master/composer.json#L41