### PR TITLE
Add `project:describe` and `env:describe` commands

### DIFF
--- a/src/Commands/EnvDescribeCommand.php
+++ b/src/Commands/EnvDescribeCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
+use RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class EnvDescribeCommand extends Command
+{
+    const DEFAULT_FORMAT = '[<comment>%setting-key%</comment>] <info>%setting-value%</info>';
+
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('env:describe')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('list', 'l', InputOption::VALUE_NONE, 'List settings')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'List format')
+            ->addArgument('setting-key', null, 'Setting key')
+            ->setDescription('Describe an environment');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Helpers::ensure_api_token_is_available();
+
+        $environment = $this->vapor->environmentNamed(
+            Manifest::id(),
+            $this->argument('environment')
+        );
+
+        $domains = $environment['latest_deployment']['root_domains'] ?: [];
+        $domain = count($domains) ? $domains[0] : null;
+
+        $description = [
+            'project_id' => $environment['project_id'],
+            'uuid' => $environment['uuid'],
+            'id' => $environment['id'],
+            'name' => $environment['name'],
+            'vanity_domain' => $environment['vanity_domain'],
+            'latest_deployment_id' => $environment['latest_deployment_id'],
+            'latest_deployment_status' => $environment['latest_deployment']['status'],
+            'latest_deployment_url' => 'https://vapor.laravel.com/app/projects/' . $environment['project_id'] . '/environments/' . $environment['name'] . '/deployments/' . $environment['latest_deployment_id'],
+            'deployment_status' => $environment['deployment_status'],
+            'domains' => $domains,
+            'domain' => $domain,
+            'management_url' => 'https://vapor.laravel.com/app/projects/' . $environment['project_id'] . '/environments/' . $environment['name'],
+            'vanity_url' => 'https://' . $environment['vanity_domain'],
+            'custom_url' => $domain ? 'https://' . $domain : null,
+        ];
+
+        // List the configuration of the file settings
+        if ($this->option('list')) {
+            $format = $this->option('format') ?: static::DEFAULT_FORMAT;
+
+            foreach ($description as $settingKey => $settingValue) {
+                if (is_bool($settingValue)) {
+                    $settingValue = var_export($settingValue, true);
+                }
+
+                if (is_array($settingValue)) {
+                    $settingValue = implode(',', $settingValue);
+                }
+
+                Helpers::line(str_replace(['%setting-key%', '%setting-value%'], [$settingKey, $settingValue], $format));
+            }
+
+            return;
+        }
+
+        $settingKey = $this->argument('setting-key');
+
+        if (!$settingKey || !is_string($settingKey)) {
+            return;
+        }
+
+        if (! array_key_exists($settingKey, $description)) {
+            throw new RuntimeException($settingKey.' is not defined');
+        }
+
+        $settingValue = $description[$settingKey];
+
+        if (is_bool($settingValue)) {
+            $settingValue = var_export($settingValue, true);
+        }
+
+        Helpers::line($settingValue);
+    }
+}

--- a/src/Commands/ProjectDescribeCommand.php
+++ b/src/Commands/ProjectDescribeCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Laravel\VaporCli\Path;
+use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
+use RuntimeException;
+use Symfony\Component\Console\Input\InputOption;
+
+class ProjectDescribeCommand extends Command
+{
+    const DEFAULT_FORMAT = '[<comment>%setting-key%</comment>] <info>%setting-value%</info>';
+
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('project:describe')
+            ->addOption('list', 'l', InputOption::VALUE_NONE, 'List settings')
+            ->addOption('format', 'f', InputOption::VALUE_REQUIRED, 'List format')
+            ->addArgument('setting-key', null, 'Setting key')
+            ->setDescription('Describe the project');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Helpers::ensure_api_token_is_available();
+
+        $settingKey = $this->argument('setting-key');
+
+        if ($settingKey && $settingKey === 'id') {
+            // If we want the ID, we can just get it.
+            Helpers::line(Manifest::id());
+
+            return;
+        }
+
+        $project = $this->vapor->project(Manifest::id());
+
+        $description = [
+            'id' => $project['id'],
+            'name' => $project['name'],
+            'team_id' => $project['team_id'],
+            'team_name' => $project['team']['name'],
+            'region' => $project['region'],
+            'github_repository' => $project['github_repository'],
+            'management_url' => 'https://vapor.laravel.com/app/projects/' . $project['id'],
+        ];
+
+        // List the configuration of the file settings
+        if ($this->option('list')) {
+            $format = $this->option('format') ?: static::DEFAULT_FORMAT;
+
+            foreach ($description as $settingKey => $settingValue) {
+                if (is_bool($settingValue)) {
+                    $settingValue = var_export($settingValue, true);
+                }
+
+                Helpers::line(str_replace(['%setting-key%', '%setting-value%'], [$settingKey, $settingValue], $format));
+            }
+
+            return;
+        }
+
+        if (!$settingKey || !is_string($settingKey)) {
+            return;
+        }
+
+        if (! array_key_exists($settingKey, $description)) {
+            throw new RuntimeException($settingKey.' is not defined');
+        }
+
+        $settingValue = $description[$settingKey];
+
+        if (is_bool($settingValue)) {
+            $settingValue = var_export($settingValue, true);
+        }
+
+        Helpers::line($settingValue);
+    }
+}

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -758,6 +758,19 @@ class ConsoleVaporClient
     }
 
     /**
+     * Get the environment by a specific name for the given project.
+     *
+     * @param  string  $projectId
+     * @return array
+     */
+    public function environmentNamed($projectId, $name)
+    {
+        return collect($this->environments($projectId))->first(function ($environment) use ($name) {
+            return $environment['name'] === $name;
+        });
+    }
+
+    /**
      * Delete the given project.
      *
      * @param  string  $projectId

--- a/vapor
+++ b/vapor
@@ -133,10 +133,12 @@ $app->add(new Commands\BalancerDeleteCommand);
 // Projects...
 $app->add(new Commands\InitCommand);
 $app->add(new Commands\ProjectDeleteCommand);
+$app->add(new Commands\ProjectDescribeCommand);
 
 // Environments...
 $app->add(new Commands\EnvListCommand);
 $app->add(new Commands\EnvCommand);
+$app->add(new Commands\EnvDescribeCommand);
 $app->add(new Commands\EnvPullCommand);
 $app->add(new Commands\EnvPushCommand);
 $app->add(new Commands\EnvCloneCommand);


### PR DESCRIPTION
These commands were inspired from `composer config` and borrows heavily from their implementation.

## Inspiration

These commands were inspired by working with GitHub Actions and seeing how tools like Composer allow you to query various settings easily for automation:

```
- name: Get Composer cache directory
  id: composer_cache
  run: echo "::set-output name=dir::$(composer config cache-files-dir)"
- name: Cache dependencies
  uses: actions/cache@v1
  with:
    path: ${{ steps.composer_cache.outputs.dir }}
    key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
    restore-keys: ${{ runner.os }}-composer-
```

Trying to do something similar in my Vapor-related workflows were a little more complicated and fragile:

```
run: |
  echo "::set-output name=vanity_url::$(./vendor/bin/vapor env:list | grep production | tr -s ' ' | cut -d ' ' -f 4)"
  echo "::set-output name=project_id::$(grep ^id: vapor.yml | cut -d ' ' -f 2)"
  echo "::set-output name=project_name::$(grep ^name: vapor.yml | cut -d ' ' -f 2-)"
```

My goal was to create some enhanced Slack notifications upon successful Vapor deployment in addition to the deployment notifications provided by Vapor already:

```
- name: Notify Slack about deploy success
  env:
    SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
  uses: 8398a7/action-slack@v3
  if: success()
  with:
    status: custom
    custom_payload: |
      {
          "attachments": [
              {
                  "mrkdwn_in": ["text"],
                  "text": ":tada: Deployed *${{ steps.vapor_details.outputs.project_name }}*",
                  "color": "good",
                  "fields": [
                      {
                          "title": "Actual URL",
                          "value": "https://beausimensen.com",
                          "short": false
                      },
                      {
                          "title": "Vanity URL",
                          "value": "${{ steps.vapor_details.outputs.vanity_url }}",
                          "short": false
                      },
                      {
                          "title": "Vapor URL",
                          "value": "https://vapor.laravel.com/app/projects/${{ steps.vapor_details.outputs.project_id }}/environments/production/deployments",
                          "short": false
                      }
                  ]
              }
          ]
      }
```

![image](https://user-images.githubusercontent.com/191200/80811821-5b336a80-8b8c-11ea-9fa9-bce8f64710c0.png)

Or, perhaps more importantly, I wanted to provide a way to send Slack notifications (with meaningful links / calls to action) on *start* of deployment or *failure* to deploy:

![image](https://user-images.githubusercontent.com/191200/80811987-a8174100-8b8c-11ea-9597-b0fd5e46b395.png)

Especially on commit to master, for my setup, I get GitHub notifications in Slack that a push happened but the actions don't send any feedback to Slack. Some time later (or maybe not) I get the Vapor notification *if deployment happened successfully*. By adding these extra notifications, I can better track what's going on.

## Default Behavior

The default behavior is to have some pretty output if you use the `--list` option. Otherwise, you can specify a specific setting key to get a plain value returned.

### `project:describe`

For `project:describe id`, we use `Manifest::id()` to avoid hitting the API.

![image](https://user-images.githubusercontent.com/191200/80812358-66d36100-8b8d-11ea-83aa-41cafc2f6e61.png)

### `env:describe <environment>`

An environment argument is required for `env:describe` to work.

The `domains` setting will be a `,` delimited string.

The `domain` setting will be the first domain if any domains exist at all or `null` if no domains exist.

The `custom_url` setting will be an `https://` prefixed `domain` setting or `null` if the `domain` setting is `null`.

![image](https://user-images.githubusercontent.com/191200/80812467-ac902980-8b8d-11ea-978b-33839753f5b3.png)

## Format

The default format for output is currently specified as:

```
[<comment>%setting-key%</comment>] <info>%setting-value%</info>
```

Both commands allow you to specify a `--format` for output with `--list`. For example, to create a `.env`-like output instead you could pass the format `%setting-key%=%setting-value%`:

![image](https://user-images.githubusercontent.com/191200/80812875-769f7500-8b8e-11ea-8b7e-0acb2fd21639.png)

Or, for my pet purposes, I could create GitHub Actions "set-output" compatible lines like `::set-output name=project.%setting-key%::%setting-value%` or `::set-output name=environment.%setting-key%::%setting-value%`:

![image](https://user-images.githubusercontent.com/191200/80812963-ac445e00-8b8e-11ea-8444-77d26281e9a6.png)

This means I can replace my GitHub Actions workflow `vapor_details` step with the following at the cost of two Vapor API calls (it only cost one with the original setup):

```
run: |
  echo "::set-output name=environment.vanity_url::$(./vendor/bin/vapor env:describe production vanity_url)"
  echo "::set-output name=project.id::$(./vendor/bin/vapor project:describe id)"
  echo "::set-output name=project.name::$(./vendor/bin/vapor project:describe name)"
```

However, I have plenty of places I could enhance or simplify if I could get everything from Vapor directly instead of doing string manipulation in my Slack templates. The ideal would probably look like this:

```
run: |
  echo "::set-output name=environment.vanity_url::$(./vendor/bin/vapor env:describe production vanity_url)"
  echo "::set-output name=environment.custom_url::$(./vendor/bin/vapor env:describe production custom_url)"
  echo "::set-output name=environment.management_url::$(./vendor/bin/vapor env:describe production management_url)"
  echo "::set-output name=project.id::$(./vendor/bin/vapor project:describe id)"
  echo "::set-output name=project.name::$(./vendor/bin/vapor project:describe name)"
  echo "::set-output name=project.management_url::$(./vendor/bin/vapor project:describe management_url)"
```

This is 6 calls to `./vendor/bin/vapor`, but the `project:describe id` call wouldn't actually result in an API call. It also _probably_ wouldn't be needed anymore since the only reason I needed it was to create the various `*_url` values that used the project's ID in the URLs that I'm no longer generating myself.

Vapor API calls may not be an issue, tho? If it is, or if it is just easier to manage, we can use the `--format` option to generate everything we could possibly need at the cost of just two total API calls:

```
run: |
  ./vendor/bin/vapor project:describe -l --format="::set-output name=project.%setting-key%::%setting-value%"
  ./vendor/bin/vapor env:describe production -l --format="::set-output name=environment.%setting-key%::%setting-value%"
```

If you only need one or two specific values, *especially if one of them is the Project ID*, I'd probably recommend the individual setting method. If you need more than that, I'd probably recommend seeing if you can get them in bulk just `--list`.

For my purposes, I'd probably move to bulk. :)

## Open Questions

### Domains

I wasn't sure how the domains stuff works at all. I only just finally got `beausimensen.com` set up as a domain. The way I was spelunking the data to find them might not be right. If there is a better way to do this (looking elsewhere, etc.) I'd be happy to dig more.

### Deployment state and latest deployment

I don't know how this will work if for some reason `latest_deployment` doesn't exist at all in the API response. I don't have any projects for which this is empty to test against.

Likewise, the `deployment_status` seems to be `null` except while a deployment is actually happening. Not sure if this is even used or meaningful?

I thought perhaps there would be a way to get a "currently deploying deployment ID" or that "latest deployment" would be the currently running deployment once a new one kicks off. This doesn't appear to be the case and maybe this isn't super useful anyway.

### Description settings

I picked settings for `project:describe` and `env:describe` based on things I thought looked like they were low-hanging fruit and things people might meaningfully want to interact with during some automation steps. Mostly names for things, ID's, and states.

The URLs were things I was very interested in having Vapor CLI generate for me, but if this is taking things too far I can take them out. Happy to discuss more.

Also, the naming for the URLs was kinda willy-nilly. "Management URL" for the "home URL" for the thing (either project or environment) seemed alright, but if there is a better name for these URLs, let's change it!

### Describe vs Config vs Show

In my head, I was wanting to find a `project:show` or `project:describe` command, but Vapor didn't have either.

I picked "describe" as I thought it fit the name better than "show" as there isn't really anything to "show"?

`composer config` makes sense as it is looking at Composer configuration *and also lets you write*, so `config` can be seen as querying and also actively configuring the Composer configuration. I didn't want to open that can of worms since I just want to be able to query Vapor for information about a project or environment and not actively configure it with these commands.

### Sorry for the book

I'm not sorry. 📖 