### PR TITLE
Add build step message for user ignored directory

### DIFF
--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -123,6 +123,8 @@ class RemoveIgnoredFiles
             [$directory, $filePattern] = $this->parsePattern($pattern);
 
             if ($this->files->exists($directory.'/'.$filePattern) && $this->files->isDirectory($directory.'/'.$filePattern)) {
+                Helpers::step('<comment>Removing Ignored Directory:</comment> '.$filePattern.'/');
+
                 $this->files->deleteDirectory($directory.'/'.$filePattern, $preserve = false);
             } else {
                 $files = (new Finder)


### PR DESCRIPTION
By default, vapor manifest comes with `'npm ci && npm run prod && rm -rf node_modules'`.
Removing node_modules is pretty much mandatory, I don't any projects will need to upload theme but who knows. 🤷‍♂️ 

I started using the `ignore` config in the manifest. As far as I understand, it doesn't make any difference in terms of IO and stuff 😄 but I find it clearer and easier to add other directories to ignore, compared to adding another `rm -rf` step to the build process.

**Did I miss something? Is there a reason I should keep the `rm -rf` instead?**

```yml
id: 1
name: coolproject
ignore:
  - node_modules
environments:
   ...
```

This PR only adds a message for deleted directory, which already exists for files (line 137).

<img width="583" alt="Screenshot 2020-05-08 at 10 28 46" src="https://user-images.githubusercontent.com/1525636/81389028-77e61a00-9119-11ea-9408-70343ceed38f.png">


