### PR TITLE
Change text styling 

### DIFF
--- a/src/BuildProcess/CollectSecrets.php
+++ b/src/BuildProcess/CollectSecrets.php
@@ -17,7 +17,7 @@ class CollectSecrets
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Collecting Secrets</>');
+        Helpers::step('<options=bold>Collecting Secrets</>');
 
         $secrets = collect(
                 Helpers::app(ConsoleVaporClient::class)

--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -18,7 +18,7 @@ class CompressApplication
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Compressing Application</>');
+        Helpers::step('<options=bold>Compressing Application</>');
 
         if (PHP_OS == 'Darwin') {
             $this->compressApplicationOnMac();

--- a/src/BuildProcess/CompressVendor.php
+++ b/src/BuildProcess/CompressVendor.php
@@ -23,7 +23,7 @@ class CompressVendor
             return;
         }
 
-        Helpers::step('<bright>Compressing Vendor Directory</>');
+        Helpers::step('<options=bold>Compressing Vendor Directory</>');
 
         if (PHP_OS == 'Darwin') {
             return $this->compressOnMac();

--- a/src/BuildProcess/ConfigureArtisan.php
+++ b/src/BuildProcess/ConfigureArtisan.php
@@ -17,7 +17,7 @@ class ConfigureArtisan
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Configuring Artisan</>');
+        Helpers::step('<options=bold>Configuring Artisan</>');
 
         file_put_contents(
             $this->appPath.'/artisan',

--- a/src/BuildProcess/ConfigureComposerAutoloader.php
+++ b/src/BuildProcess/ConfigureComposerAutoloader.php
@@ -20,7 +20,7 @@ class ConfigureComposerAutoloader
             return;
         }
 
-        Helpers::step('<bright>Configuring Composer Autoloader</>');
+        Helpers::step('<options=bold>Configuring Composer Autoloader</>');
 
         file_put_contents(
             $this->appPath.'/vendor/composer/autoload_static.php',

--- a/src/BuildProcess/CopyApplicationToBuildPath.php
+++ b/src/BuildProcess/CopyApplicationToBuildPath.php
@@ -17,7 +17,7 @@ class CopyApplicationToBuildPath
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Copying Application Files</>');
+        Helpers::step('<options=bold>Copying Application Files</>');
 
         $this->ensureBuildDirectoryExists();
 

--- a/src/BuildProcess/ExecuteBuildCommands.php
+++ b/src/BuildProcess/ExecuteBuildCommands.php
@@ -17,7 +17,7 @@ class ExecuteBuildCommands
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Executing Build Commands</>');
+        Helpers::step('<options=bold>Executing Build Commands</>');
 
         foreach (Manifest::buildCommands($this->environment) as $command) {
             Helpers::step('<comment>Running Command</comment>: '.$command);

--- a/src/BuildProcess/ExtractAssetsToSeparateDirectory.php
+++ b/src/BuildProcess/ExtractAssetsToSeparateDirectory.php
@@ -17,7 +17,7 @@ class ExtractAssetsToSeparateDirectory
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Extracting Assets</>');
+        Helpers::step('<options=bold>Extracting Assets</>');
 
         $this->ensureAssetDirectoryExists();
 

--- a/src/BuildProcess/ExtractVendorToSeparateDirectory.php
+++ b/src/BuildProcess/ExtractVendorToSeparateDirectory.php
@@ -21,7 +21,7 @@ class ExtractVendorToSeparateDirectory
             return;
         }
 
-        Helpers::step('<bright>Extracting Vendor Files</>');
+        Helpers::step('<options=bold>Extracting Vendor Files</>');
 
         (new Filesystem)->move(
             $this->appPath.'/vendor',

--- a/src/BuildProcess/HarmonizeConfigurationFiles.php
+++ b/src/BuildProcess/HarmonizeConfigurationFiles.php
@@ -16,7 +16,7 @@ class HarmonizeConfigurationFiles
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Harmonizing Configuration Files</>');
+        Helpers::step('<options=bold>Harmonizing Configuration Files</>');
 
         $configFiles = (new Finder)->files()->in($this->appPath.'/config');
 

--- a/src/BuildProcess/InjectErrorPages.php
+++ b/src/BuildProcess/InjectErrorPages.php
@@ -15,7 +15,7 @@ class InjectErrorPages
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Injecting Error Pages</>');
+        Helpers::step('<options=bold>Injecting Error Pages</>');
 
         $stubPath = $this->appPath.'/vendor/laravel/vapor-core/stubs';
 

--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -16,7 +16,7 @@ class InjectHandlers
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Injecting Serverless Handlers</>');
+        Helpers::step('<options=bold>Injecting Serverless Handlers</>');
 
         if (! is_dir($this->appPath.'/vendor/laravel/vapor-core')) {
             Helpers::abort('Unable to find laravel/vapor-core installation.');

--- a/src/BuildProcess/InjectRdsCertificate.php
+++ b/src/BuildProcess/InjectRdsCertificate.php
@@ -15,7 +15,7 @@ class InjectRdsCertificate
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Injecting RDS SSL Certificate</>');
+        Helpers::step('<options=bold>Injecting RDS SSL Certificate</>');
 
         $stubPath = $this->appPath.'/vendor/laravel/vapor-core/stubs';
 

--- a/src/BuildProcess/ProcessAssets.php
+++ b/src/BuildProcess/ProcessAssets.php
@@ -40,7 +40,7 @@ class ProcessAssets
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Processing Assets</>');
+        Helpers::step('<options=bold>Processing Assets</>');
 
         foreach (AssetFiles::get($this->appPath.'/public') as $file) {
             if (! Str::endsWith($file->getRealPath(), '.css')) {

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -19,7 +19,7 @@ class RemoveIgnoredFiles
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Removing Ignored Files</>');
+        Helpers::step('<options=bold>Removing Ignored Files</>');
 
         $this->removeDefaultIgnoredFiles();
         $this->removeDefaultIgnoredDirectories();

--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -42,7 +42,7 @@ class SetBuildEnvironment
      */
     public function __invoke()
     {
-        Helpers::step('<bright>Setting Build Environment</>');
+        Helpers::step('<options=bold>Setting Build Environment</>');
 
         if (! file_exists($envPath = $this->appPath.'/.env')) {
             $this->files->put($envPath, '');

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -80,10 +80,6 @@ class Command extends SymfonyCommand
     protected function configureOutputStyles(OutputInterface $output)
     {
         $output->getFormatter()->setStyle(
-            'bright', new OutputFormatterStyle('white', 'default', ['bold'])
-        );
-
-        $output->getFormatter()->setStyle(
             'finished', new OutputFormatterStyle('green', 'default', ['bold'])
         );
     }

--- a/src/Commands/CommandCommand.php
+++ b/src/Commands/CommandCommand.php
@@ -41,7 +41,7 @@ class CommandCommand extends Command
             $this->option('command') ?? Helpers::ask('What command would you like to execute')
         );
 
-        Helpers::step('<bright>Executing Function...</>'.PHP_EOL);
+        Helpers::step('<options=bold>Executing Function...</>'.PHP_EOL);
 
         // We will poll the backend service to get the invocations status and wait until
         // it gets done processing. Once it's done we will be able to show the status

--- a/src/Commands/DisplaysDeploymentProgress.php
+++ b/src/Commands/DisplaysDeploymentProgress.php
@@ -67,7 +67,7 @@ trait DisplaysDeploymentProgress
     protected function displayActiveDeploymentSteps(Deployment $deployment)
     {
         foreach ($deployment->displayableSteps($this->displayedSteps) as $step) {
-            Helpers::step("<bright>{$step}</bright>");
+            Helpers::step("<options=bold>{$step}</>");
 
             $this->displayedSteps[] = $step;
         }

--- a/src/Commands/DownCommand.php
+++ b/src/Commands/DownCommand.php
@@ -33,7 +33,7 @@ class DownCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
-        Helpers::step('<bright>Initiating Maintenance Mode Deployment</bright>');
+        Helpers::step('<options=bold>Initiating Maintenance Mode Deployment</>');
 
         $deployment = $this->displayDeploymentProgress(
             $this->vapor->enableMaintenanceMode(Manifest::id(), $this->argument('environment'))

--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -32,7 +32,7 @@ class EnvPullCommand extends Command
 
         $environment = $this->argument('environment');
 
-        Helpers::step('<bright>Downloading Environment File...</>');
+        Helpers::step('<options=bold>Downloading Environment File...</>');
 
         file_put_contents(
             getcwd().'/.env.'.$environment,

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -36,7 +36,7 @@ class EnvPushCommand extends Command
             Helpers::abort('The environment variables for that environment have not been downloaded.');
         }
 
-        Helpers::step('<bright>Uploading Environment File...</>');
+        Helpers::step('<options=bold>Uploading Environment File...</>');
 
         $this->vapor->updateEnvironmentVariables(
             Manifest::id(), $environment, file_get_contents($file)

--- a/src/Commands/Output/DeploymentSuccess.php
+++ b/src/Commands/Output/DeploymentSuccess.php
@@ -34,8 +34,8 @@ class DeploymentSuccess
                 '<comment>Deployment ID</comment>',
                 '<comment>Environment URL (Copied To Clipboard)</comment>'
             ], [[
-                "<bright>{$deployment->id}</>",
-                "<bright>https://{$deployment->vanityDomain()}</>",
+                "<options=bold>{$deployment->id}</>",
+                "<options=bold>https://{$deployment->vanityDomain()}</>",
             ]]);
         }
     }

--- a/src/Commands/RedeployCommand.php
+++ b/src/Commands/RedeployCommand.php
@@ -33,7 +33,7 @@ class RedeployCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
-        Helpers::step('<bright>Initiating Redeployment</bright>');
+        Helpers::step('<options=bold>Initiating Redeployment</>');
 
         $deployment = $this->displayDeploymentProgress(
             $this->vapor->redeploy(Manifest::id(), $this->argument('environment'))

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -50,7 +50,7 @@ class RollbackCommand extends Command
             $this->formatDeployments($deployments)
         );
 
-        Helpers::step('<bright>Initiating Rollback</bright>');
+        Helpers::step('<options=bold>Initiating Rollback</>');
 
         // Once the rollback is running we will show the deployment pipeline as when
         // running a typical deployment. After the deployment is over we can push

--- a/src/Commands/UpCommand.php
+++ b/src/Commands/UpCommand.php
@@ -33,7 +33,7 @@ class UpCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
-        Helpers::step('<bright>Initiating Active Mode Deployment</bright>');
+        Helpers::step('<options=bold>Initiating Active Mode Deployment</>');
 
         $deployment = $this->displayDeploymentProgress(
             $this->vapor->disableMaintenanceMode(Manifest::id(), $this->argument('environment'))


### PR DESCRIPTION
Currently used styling for "steps" assumes dark background which is hard to read in a terminal with a white background. This PR removes this assumption and simply prints the text in bold. 

See the screenshots below:

**Before**:
<img width="946" alt="Screenshot 2020-05-28 at 14 26 53" src="https://user-images.githubusercontent.com/4470539/83141070-5c09de80-a0ef-11ea-8a3e-99166fcb6b4f.png">
<img width="946" alt="Screenshot 2020-05-28 at 14 27 00" src="https://user-images.githubusercontent.com/4470539/83141067-59a78480-a0ef-11ea-9da0-e97bd5df5874.png">

**After**:
<img width="946" alt="Screenshot 2020-05-28 at 14 14 18" src="https://user-images.githubusercontent.com/4470539/83140783-e9006800-a0ee-11ea-84bd-75ee9e1c092e.png">
<img width="946" alt="Screenshot 2020-05-28 at 14 14 25" src="https://user-images.githubusercontent.com/4470539/83140774-e6057780-a0ee-11ea-8589-1773aeb8f3bb.png">