### PR TITLE
Add team:set command

### DIFF
--- a/src/Commands/TeamSetCommand.php
+++ b/src/Commands/TeamSetCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Laravel\VaporCli\Config;
+use Laravel\VaporCli\Helpers;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class TeamSetCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('team:set')
+            ->addArgument('team', InputArgument::REQUIRED, 'The team ID/Name to set')
+            ->addOption('use-name', null, InputOption::VALUE_NONE, 'Use team Name instead of ID')
+            ->setDescription('Manually set a team using ID or Name');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Helpers::ensure_api_token_is_available();
+
+        $allTeams = array_merge(
+            $this->vapor->ownedTeams(),
+            $this->vapor->teams()
+        );
+
+        $teams = collect($allTeams)->where($this->option('use-name') ? 'name' : 'id', $this->argument('team'));
+
+        if($teams->count() < 1)
+        {
+            Helpers::abort('No team found.');
+        }
+
+        if($teams->count() > 1)
+        {
+            Helpers::abort('More than one team found with criteria.');
+        }
+
+        $team = $teams->first();
+
+        $this->vapor->switchCurrentTeam($team['id']);
+
+        Config::set('team', $team['id']);
+
+        Helpers::line('<info>Current team context set to</info> <comment>['.$team['name'].']</comment>');
+    }
+}

--- a/vapor
+++ b/vapor
@@ -60,6 +60,7 @@ $app->add(new Commands\LoginCommand);
 // Teams...
 $app->add(new Commands\TeamListCommand);
 $app->add(new Commands\TeamCommand);
+$app->add(new Commands\TeamSetCommand);
 $app->add(new Commands\TeamCurrentCommand);
 $app->add(new Commands\TeamSwitchCommand);
 $app->add(new Commands\MemberListCommand);


### PR DESCRIPTION
Added `team:set` command, came up with this idea while trying to set-up a Github Action using Vapor CLI and couldn't switch team easily through my workflow.

Argument `team` would expect a valid **Team ID** for the User.
**Team Name** can also be used as long as `--use-name` option is also passed along.