### PR TITLE
Add project:dashboard command

### DIFF
--- a/src/Commands/ProjectDashboardCommand.php
+++ b/src/Commands/ProjectDashboardCommand.php
@@ -4,7 +4,6 @@ namespace Laravel\VaporCli\Commands;
 
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Manifest;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Process\Process;
 
 class ProjectDashboardCommand extends Command

--- a/src/Commands/ProjectDashboardCommand.php
+++ b/src/Commands/ProjectDashboardCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Process\Process;
+
+class ProjectDashboardCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('project:dashboard')
+            ->setDescription('Open the current project in Vapor\'s dashboard');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Helpers::ensure_api_token_is_available();
+
+        $url = 'https://vapor.laravel.com/app/projects/'.Manifest::id();
+        Helpers::info("Opening $url in the default browser...");
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            Process::fromShellCommandline('start '.escapeshellarg($url))->run();
+        } else {
+            Process::fromShellCommandline('open '.escapeshellarg($url))->run();
+        }
+    }
+}

--- a/vapor
+++ b/vapor
@@ -132,6 +132,7 @@ $app->add(new Commands\BalancerDeleteCommand);
 
 // Projects...
 $app->add(new Commands\InitCommand);
+$app->add(new Commands\ProjectDashboardCommand);
 $app->add(new Commands\ProjectDeleteCommand);
 $app->add(new Commands\ProjectDescribeCommand);
 


### PR DESCRIPTION
Hello!

This adds a `vapor project:dashboard` command that opens the current project in Vapor's dashboard.
I wanted to have this command available, hopefully you find it useful too. I was a little surprised this was not built in considering Vapor's focus on the CLI. The CLI is so good, that you may not have the web dashboard open, so a quick and easy way to access it feels right.

I thought `vapor open` would be more ergonomic, but that would get confused with `valet open` which has a different intent.

Didn't tested it in windows but used the `start` command [as they use in valet-windows](https://github.com/cretueusebiu/valet-windows/blob/master/cli/valet.php#L205).

What do you think?