### PR TITLE
Add Composer 2 Support

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -263,6 +263,9 @@ class DeployCommand extends Command
         }
 
         $version = collect(json_decode(file_get_contents($file)))
+                ->pipe(function ($composer) {
+                    return collect($composer->get('packages', $composer));
+                })
                 ->where('name', 'laravel/vapor-core')
                 ->first()->version;
 


### PR DESCRIPTION
composer v2 changed the format of `installed.json`, this PR added a support for the new format while still maintaining support for composer v1.

References:
https://github.com/composer/composer/blob/master/UPGRADE-2.0.md