### PR TITLE
Actually remove filter on json assets as intended

### DIFF
--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -27,7 +27,6 @@ class AssetFiles
                 ->notName('web.config')
                 ->notName('browserconfig.xml')
                 ->notName('*.webmanifest')
-                ->notName('*.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
                 ->ignoreDotFiles(true)


### PR DESCRIPTION
In #35, the intended change, judging by the description, seems to be that all JSON files should be included in the assets upload. However, the actual effect of #35 was that all JSON files were _excluded_ in the assets upload.

This change removes the filter on JSON asset files entirely.

This problem was also [noted](https://github.com/laravel/vapor-cli/pull/35#commitcomment-37478742) by @jonboc.