### PR TITLE
Revert recent changes resulting in problems with `mix-manifest.json`

### DIFF
--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -27,6 +27,7 @@ class AssetFiles
                 ->notName('web.config')
                 ->notName('browserconfig.xml')
                 ->notName('*.webmanifest')
+                ->notName('mix-manifest.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
                 ->ignoreDotFiles(true)


### PR DESCRIPTION
This is only triage to get Laravel Mix working again. Additional work may be required to get Livewire's `manifest.json` working correctly.

This reverts #67 f2e34ab3d6cf4b4ee5e917c83b56aea6ae0d0682 which was an attempt to fix #35 758214a02c1422b99997df8f608820add37d6c88.

The end result of #67 was mix-manifest.json being included in the asset artifact and being removed from the code deployment artifact. This meant Laravel Mix applications would fail as they expect to be able to read the contents of `public/mix-manifest.json` at runtime.

This does not attempt to fix the original issue #35 was trying to address. #35 would have included `public/manifest.json` in the code deployment artifact (the desired behavior) but #67 would ensure both `public/manifest.json` and `public/mix-manifest.json` would end up in the asset artifact.

Unclear if Livewire's `manifest.json` is needed by both client (so needs to be a part of the asset artifact) and code (so also needs to be in the code deployment artifact) so not trying to make that decision now.

----

[See this comment](https://github.com/laravel/vapor-cli/pull/67#issuecomment-691504466) on #67 regarding my proposal for solving this problem in a more generic way by allowing people to specify which public assets should be included only in the code deployment artifact or *also* in the code deployment artifact.

TL;DR: For example, allowing `vapor.yml` to support specifying paths and patterns like this:

```yaml
public_assets:
    # Files that are only needed by code and can be removed from
    # the asset artifact.
    only_in_code_artifact:
        - mix-manifest.json
    # Files that are needed by BOTH the code and also need to be
    # included in the asset artifact
    also_in_code_artifact:
        - manifest.json
        - images/logos/*.svg
        - images/icons/*.svg
```

