### PR TITLE
Ensure manifest.json stays in the code deployment artifact for Laravel Livewire

### DIFF
--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -27,6 +27,7 @@ class AssetFiles
                 ->notName('web.config')
                 ->notName('browserconfig.xml')
                 ->notName('*.webmanifest')
+                ->notName('manifest.json')
                 ->notName('mix-manifest.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)


### PR DESCRIPTION
This pull request aims to support Laravel Liveware separate from Laravel Mix.

It is not clear to me if this is correct, though. Does Laravel Livewire need to access `public/manifest.json` from the client, or only from the code? If it needs to be accessed from both, I don't know if it is possible to easily support `public/manifest.json` in both the asset artifact and the code deployment artifact at this time.

See #68, #67, #35 for reference.