### PR TITLE
Adds the possibility of interpret dot files in the public directory as assets

### DIFF
--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -31,6 +31,7 @@ class AssetFiles
                 ->notName('mix-manifest.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
+                ->ignoreDotFiles(false)
                 ->sortByName();
     }
 

--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -31,7 +31,7 @@ class AssetFiles
                 ->notName('mix-manifest.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
-                ->ignoreDotFiles(! Manifest::dotFilesAsAssets())
+                ->ignoreDotFiles(!Manifest::dotFilesAsAssets())
                 ->sortByName();
     }
 

--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -31,7 +31,7 @@ class AssetFiles
                 ->notName('mix-manifest.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
-                ->ignoreDotFiles(!Manifest::dotFilesAsAssets())
+                ->ignoreDotFiles(! Manifest::dotFilesAsAssets())
                 ->sortByName();
     }
 

--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -31,7 +31,6 @@ class AssetFiles
                 ->notName('mix-manifest.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
-                ->ignoreDotFiles(true)
                 ->sortByName();
     }
 

--- a/src/AssetFiles.php
+++ b/src/AssetFiles.php
@@ -31,7 +31,7 @@ class AssetFiles
                 ->notName('mix-manifest.json')
                 ->notName('*.php')
                 ->ignoreVcs(true)
-                ->ignoreDotFiles(false)
+                ->ignoreDotFiles(!Manifest::dotFilesAsAssets())
                 ->sortByName();
     }
 

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -68,6 +68,16 @@ class Manifest
     }
 
     /**
+     * Determine if we should interpret dot files in the public directory as assets.
+     *
+     * @return bool
+     */
+    public static function dotFilesAsAssets()
+    {
+        return static::current()['dot-files-as-assets'] ?? false;
+    }
+
+    /**
      * Write a fresh manifest file for the given project.
      *
      * @param array $project


### PR DESCRIPTION
This pull request adds the possibility of interpret dot files in the public directory as assets.

To enable this option, developers need to add the following option to their `vapor.yml`:

```yml
id: 1
name: test
dot-files-as-assets: true
```

Since this is optional, there is no breaking changes on existing applications.

As mentioned on [this pull request](https://github.com/laravel/vapor-core/pull/61): This is particular useful for developers deploying PWAs using Vapor, as they may want to serve assets that contain dots: `your-domain.com/.well-known/assetlinks.json`.