### PR TITLE
Adds support to PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,17 +37,10 @@ jobs:
           echo "::add-matcher::${{ runner.tool_cache }}/php.json"
           echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-      - name: Install PHP 7 dependencies
+      - name: Install PHP dependencies
         run: |
            composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
            composer update --prefer-dist --no-interaction --no-progress
-        if: "matrix.php < 8"
-
-      - name: Install PHP 8 dependencies
-        run: |
-           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
-           composer update --prefer-dist --no-interaction --no-progress
-        if: "matrix.php >= 8"
 
       - name: Execute unit tests
         run: vendor/bin/phpunit --testsuite=Unit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Install PHP 8 dependencies
         run: |
-           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update --ignore-platform-req=php
-           composer update --prefer-dist --no-interaction --no-progress --ignore-platform-req=php
+           composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
+           composer update --prefer-dist --no-interaction --no-progress
         if: "matrix.php >= 8"
 
       - name: Execute unit tests

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "vapor"
     ],
     "require": {
+        "php": "^7.2|^8.0",
         "ext-zip": "*",
         "guzzlehttp/guzzle": "^6.3|^7.0",
         "illuminate/container": "^6.0|^7.0|^8.0",
@@ -32,7 +33,7 @@
         "vlucas/phpdotenv": "^3.0|^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -746,7 +746,7 @@ class ConsoleVaporClient
      *
      * @return array
      */
-    public function requestCertificate($providerId, $domain, array $alternativeNames = [], $region, $validationMethod)
+    public function requestCertificate($providerId, $domain, array $alternativeNames, $region, $validationMethod)
     {
         $this->requestWithErrorHandling('post', '/api/teams/'.Helpers::config('team').'/certificates', [
             'cloud_provider_id' => $providerId,


### PR DESCRIPTION
This pull request makes `vapor-cli` support PHP 8.

Todo/Requirements:

- [x] Laravel Framework PHP 8 support: https://github.com/laravel/framework/pull/33388.
- [x] Re-test this pull request once all requirements are meet.