### PR TITLE
Adds protected environment check

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -49,7 +49,7 @@ class DeployCommand extends Command
         // Checks if the environment is protected and prompts the user
         // if the user choice is Yes, deployment completed, otherwise
         // deployment exits.
-        if(!$this->checkProtectedEnvironment($this->argument('environment'))) {
+        if (!$this->checkProtectedEnvironment($this->argument('environment'))) {
             exit(1);
         }
 
@@ -301,7 +301,7 @@ class DeployCommand extends Command
      */
     protected function checkProtectedEnvironment($environment)
     {
-        if(Manifest::isProtectedEnvironment($environment)) {
+        if (Manifest::isProtectedEnvironment($environment)) {
             return Helpers::confirm('This is a protected environment, are you sure you want to deploy?', false);
         }
     }

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -49,8 +49,8 @@ class DeployCommand extends Command
         // Checks if the environment is protected and prompts the user
         // if the user choice is Yes, deployment completed, otherwise
         // deployment exits.
-        if(!$this->checkProtectedEnvironment($this->argument('environment'))){
-            return;
+        if(!$this->checkProtectedEnvironment($this->argument('environment'))) {
+            exit(1);
         }
 
         // First we will build the project and create a new deployment artifact for the
@@ -67,7 +67,8 @@ class DeployCommand extends Command
             Manifest::current()
         ));
 
-        if ($this->option('without-waiting')) {
+        if ($this->option('without-waiting'))
+        {
             Helpers::line();
 
             return Helpers::info('Artifact uploaded successfully.');
@@ -300,8 +301,7 @@ class DeployCommand extends Command
      */
     protected function checkProtectedEnvironment($environment)
     {
-        if(Manifest::isProtectedEnvironment($environment))
-        {
+        if(Manifest::isProtectedEnvironment($environment)) {
             return Helpers::confirm('This is a protected environment, are you sure you want to deploy?', false);
         }
     }

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -46,6 +46,13 @@ class DeployCommand extends Command
 
         $this->ensureManifestIsValid();
 
+        // Checks if the environment is protected and prompts the user
+        // if the user choice is Yes, deployment completed, otherwise
+        // deployment exits.
+        if(!$this->checkProtectedEnvironment($this->argument('environment'))){
+            return;
+        }
+
         // First we will build the project and create a new deployment artifact for the
         // project deployment. Once that has been done we can upload the assets into
         // storage so that they can be accessed publicly or displayed on the site.
@@ -283,5 +290,19 @@ class DeployCommand extends Command
                 ->first()->version;
 
         return ltrim($version, 'v');
+    }
+
+    /**
+     * Check whether the environment is protected before deployment.
+     *
+     * @param $environment
+     * @return mixed
+     */
+    protected function checkProtectedEnvironment($environment)
+    {
+        if(Manifest::isProtectedEnvironment($environment))
+        {
+            return Helpers::confirm('This is a protected environment, are you sure you want to deploy?', false);
+        }
     }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -184,4 +184,19 @@ class Manifest
             Yaml::dump($manifest, $inline = 20, $spaces = 4)
         );
     }
+
+    /**
+     * Determines whether the environment is protected or not
+     *
+     * @param $environment
+     * @return array|mixed
+     */
+    public static function isProtectedEnvironment($environment)
+    {
+        if (!isset(static::current()['environments'][$environment])) {
+            Helpers::abort("The [{$environment}] environment has not been defined.");
+        }
+
+        return static::current()['environments'][$environment]['protected'] ?? [];
+    }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -189,6 +189,7 @@ class Manifest
      * Determines whether the environment is protected or not.
      *
      * @param $environment
+     * 
      * @return array|mixed
      */
     public static function isProtectedEnvironment($environment)

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -186,7 +186,7 @@ class Manifest
     }
 
     /**
-     * Determines whether the environment is protected or not
+     * Determines whether the environment is protected or not.
      *
      * @param $environment
      * @return array|mixed


### PR DESCRIPTION
This PR will add a new check to `vapor/cli`, if the target environment has a `protected` parameter set to true in `vapor.yml`, the CLI will ask for user confirmation before deployment. This is very similar to `artisan migrate` when running in production environment.