### PR TITLE
Retries requests after the given retry-after

### DIFF
--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1385,7 +1385,7 @@ class ConsoleVaporClient
             if ($response->getStatusCode() === 429 && $response->hasHeader('retry-after') && $tries < 3) {
                 $retryAfter = $response->getHeader('retry-after')[0];
                 Helpers::line("You are attempting this action too often. Retrying again in $retryAfter seconds...");
-                sleep($retryAfter);
+                sleep($retryAfter + 1);
 
                 return $this->request($method, $uri, $json, $tries + 1);
             }

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1384,7 +1384,9 @@ class ConsoleVaporClient
 
             if ($response->getStatusCode() === 429 && $response->hasHeader('retry-after') && $tries < 3) {
                 $retryAfter = $response->getHeader('retry-after')[0];
-                Helpers::line("You are attempting this action too often. Retrying again in $retryAfter seconds...");
+
+                Helpers::line("You are attempting this action too often. Retrying in [{$retryAfter}] seconds...");
+
                 sleep($retryAfter + 1);
 
                 return $this->request($method, $uri, $json, $tries + 1);

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1371,15 +1371,26 @@ class ConsoleVaporClient
      * @param string $method
      * @param string $uri
      * @param array  $json
+     * @param int    $tries
      *
      * @return array
      */
-    protected function request($method, $uri, array $json = [])
+    protected function request($method, $uri, array $json = [], $tries = 0)
     {
         try {
             return $this->requestWithoutErrorHandling($method, $uri, $json);
         } catch (ClientException $e) {
-            $this->displayRequestErrors($e->getResponse());
+            $response = $e->getResponse();
+
+            if ($response->getStatusCode() === 429 && $response->hasHeader('retry-after') && $tries < 3) {
+                $retryAfter = $response->getHeader('retry-after')[0];
+                Helpers::line("You are attempting this action too often. Retrying again in $retryAfter seconds...");
+                sleep($retryAfter);
+
+                return $this->request($method, $uri, $json, $tries + 1);
+            }
+
+            $this->displayRequestErrors($response);
 
             throw $e;
         }


### PR DESCRIPTION
This pull request makes usage of the header `retry-after` to retry similar requests at least 3 times to avoid deployments get canceled because of rate limits.

<img width="706" alt="Screenshot 2020-10-22 at 12 36 15" src="https://user-images.githubusercontent.com/5457236/96860555-2df0b680-1463-11eb-8234-8cedd4330a0b.png">

