### PR TITLE
Removes vendor platform check

### DIFF
--- a/src/BuildProcess/RemoveVendorPlatformCheck.php
+++ b/src/BuildProcess/RemoveVendorPlatformCheck.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Laravel\VaporCli\BuildProcess;
+
+use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Path;
+
+class RemoveVendorPlatformCheck
+{
+    use ParticipatesInBuildProcess;
+
+    /**
+     * Execute the build process step.
+     *
+     * @return void
+     */
+    public function __invoke()
+    {
+        Helpers::step('<options=bold>Removing Composer Platform Check</>');
+
+        if ($this->files->exists($path = Path::app().'/vendor/composer/platform_check.php')) {
+            $this->files->put($path, '<?php'.PHP_EOL);
+        }
+    }
+}

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -18,6 +18,7 @@ use Laravel\VaporCli\BuildProcess\InjectHandlers;
 use Laravel\VaporCli\BuildProcess\InjectRdsCertificate;
 use Laravel\VaporCli\BuildProcess\ProcessAssets;
 use Laravel\VaporCli\BuildProcess\RemoveIgnoredFiles;
+use Laravel\VaporCli\BuildProcess\RemoveVendorPlatformCheck;
 use Laravel\VaporCli\BuildProcess\SetBuildEnvironment;
 use Laravel\VaporCli\Helpers;
 use Symfony\Component\Console\Input\InputArgument;
@@ -60,6 +61,7 @@ class BuildCommand extends Command
             new ConfigureArtisan(),
             new ConfigureComposerAutoloader(),
             new RemoveIgnoredFiles(),
+            new RemoveVendorPlatformCheck(),
             new ProcessAssets($this->option('asset-url')),
             new ExtractAssetsToSeparateDirectory(),
             new InjectHandlers(),


### PR DESCRIPTION
**Composer 2** introduces https://php.watch/articles/composer-platform-check: The server environment is checked at the run-time before the autoloader is even initialized. Examples of errors that can appear on CloudWatch when functions failed to boot:

```
Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 7.3.0" and "< 7.4.0". You are running 7.4.5. Your Composer dependencies require the following PHP extensions to be installed: pdo, xml
```

Now, while this can be considered a cool feature, using this in Vapor runtime/deployments this can lead to unexpected behavior. For a couple of reasons:

1. HTTP functions won't boot because Vapor runtime often don't have all the extensions required by packages. Note that, not having all the required extensions sometimes is fine, because sometimes users don't use the features that require those extensions.
2. CLI functions won't boot because Vapor runtime often don't have all the extensions required by packages. This will block all deployments because the Vapor API won't receive Hook responses from deploy hooks.

This pull request proposes the removal of the Platform Check file, so this check is not performed in Vapor runtimes.