### PR TITLE
Uses output json in Command output

### DIFF
--- a/src/Commands/CommandCommand.php
+++ b/src/Commands/CommandCommand.php
@@ -52,14 +52,6 @@ class CommandCommand extends Command
 
         $this->displayOutput($command);
 
-        // If there were problems with the invocation, we will display the logs for this
-        // invocation. Logs can take a minute to propogate to CloudWatch so they will
-        // not always be immediately available for viewing by an invocation author.
-        $this->displayLog(
-            $command,
-            $command['status_code'] ?? null
-        );
-
         Helpers::line();
         Helpers::line('<fg=magenta>Vapor Command ID:</> '.$command['id']);
         Helpers::line('<fg=magenta>AWS Request ID:</> '.$command['request_id']);
@@ -127,7 +119,14 @@ class CommandCommand extends Command
         if (isset($command['output'])) {
             Helpers::comment('Output:');
 
-            Helpers::write(PHP_EOL.base64_decode($command['output']));
+            $output = $command['output'];
+            $output = base64_decode($output);
+
+            if ($json = json_decode($output, true)) {
+                $output = $json['output'];
+            }
+
+            Helpers::write($output);
         }
     }
 


### PR DESCRIPTION
This pull requests does two things:

1. Improves the output of the `command` vapor cli command making it pretty just like `hook:output` vapor cli command.
2. Removes the functions logs of the `command` vapor cli command, as the that logs will never be available for display.

<img width="1920" alt="Screenshot 2020-10-29 at 10 45 30" src="https://user-images.githubusercontent.com/5457236/97552318-66007800-19d4-11eb-95cb-33c0cf959119.png">
