### PR TITLE
Fixes required parameter following optional parameter on PHP8

### DIFF
--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -35,7 +35,7 @@ class AwsStorageProvider
      *
      * @return void
      */
-    public function store($url, array $headers = [], $file, $withProgress = false)
+    public function store($url, array $headers, $file, $withProgress = false)
     {
         $stream = fopen($file, 'r+');
 


### PR DESCRIPTION
This pull request fixes a warning while using PHP 8 with `vapor-cli`:
```
PHP Deprecated:  Required parameter $file follows optional parameter $headers in /Users/nunomaduro/.composer/vendor/laravel/vapor-cli/src/Aws/AwsStorageProvider.php on line 38
```