### PR TITLE
Fixes VendorHash generation with  "--no-dev" option

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -251,7 +251,7 @@ class DeployCommand extends Command
      */
     protected function createVendorHash()
     {
-        return md5(md5_file(Path::app().'/composer.json').md5_file(Path::app().'/composer.lock').md5_file(Path::vendor().'/composer/autoload_real.php'));
+        return md5(md5_file(Path::app().'/composer.json').md5_file(Path::app().'/composer.lock').md5_file(Path::vendor().'/composer/installed.json'));
     }
 
     /**


### PR DESCRIPTION
This pull request addresses an issue that can happen while using the **"separate-vendor"** option.

The **"VendorHash" will be the same** ( vendor will be reused ) for two environments where **only one of them uses the "--no-dev"** composer option.

Here is an example:

1. User deploys production using "vapor deploy production", and the vendor artifact doesn't contain dev dependencies - vendor artifact gets uploaded.
2. User deploys staging using "vapor deploy", and the vendor artifact will be reused from action 1. Yet the code ( cache files for example ) thinks that there are dev dependencies.
3. Deploy hooks failed with errors like so: "Class 'Barryvdh\\Debugbar\\ServiceProvider' not found".

The fix consists of using **"composer/installed.json"** instead of "autoload_real.php" while generating the "VendorHash". The file "composer/installed.json", contains more information about packages installed on the Vendor folder, so the "VendorHash" will be different from an environment with vs without dev dependencies. 

Tests were made using Composer v1, and Composer v2 to make sure we are not shipping something broken here:
```
// Hash
// 8bab9e2b477d3ec30aa8a45abf26302e : Composer v1 - "composer install --no-dev"
// 8bab9e2b477d3ec30aa8a45abf26302e : Composer v1 - "composer install --no-dev"
// 88d4b3aa022153e711b2765b25dd2349 : Composer v1 - "composer install"
// 88d4b3aa022153e711b2765b25dd2349 : Composer v1 - "composer install"
// bade379c3bdbb399a45dacf01146f82f   : Composer v2 - "composer install"
// bade379c3bdbb399a45dacf01146f82f   : Composer v2 - "composer install"
// 99d83cd6106756dd19aef0b55f219679  : Composer v2 - "composer install --no-dev"
// 99d83cd6106756dd19aef0b55f219679  : Composer v2 - "composer install --no-dev"
```