### PR TITLE
Uses Amazon Linux 2 and PHP 8 by default

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -131,7 +131,7 @@ class Manifest
                 'production' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-7.4',
+                    'runtime'    => 'php-8.0:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                         'php artisan event:cache',
@@ -141,7 +141,7 @@ class Manifest
                 'staging' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-7.4',
+                    'runtime'    => 'php-8.0:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install',
                         'php artisan event:cache',


### PR DESCRIPTION
This pull request makes Vapor CLI creates a default `vapor.yml` with Amazon Linux 2 and PHP 8 by default.

<img width="498" alt="Screenshot 2020-12-17 at 16 20 54" src="https://user-images.githubusercontent.com/5457236/102506863-dc8c2e80-4083-11eb-952b-50dac190b392.png">
