### PR TITLE
Adds a step to validate manifest file

### DIFF
--- a/src/BuildProcess/ValidateManifest.php
+++ b/src/BuildProcess/ValidateManifest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Laravel\VaporCli\BuildProcess;
+
+use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
+
+class ValidateManifest
+{
+    use ParticipatesInBuildProcess;
+
+    /**
+     * Execute the build process step.
+     *
+     * @return void
+     */
+    public function __invoke()
+    {
+        Helpers::step('<options=bold>Validating Manifest File</>');
+
+        $this->warnAboutDeprecations();
+    }
+
+    /**
+     * Check and warn about deprecations, if any.
+     *
+     * @return $this
+     */
+    protected function warnAboutDeprecations()
+    {
+        if (Manifest::shouldSeparateVendor($this->environment)) {
+            Helpers::warn(
+                '- The "separate-vendor" option is deprecated.'
+                .' Please use docker based deployments instead:'
+                .' https://docs.vapor.build/1.0/projects/environments.html#runtime'
+            );
+        }
+
+        return $this;
+    }
+}

--- a/src/BuildProcess/ValidateManifest.php
+++ b/src/BuildProcess/ValidateManifest.php
@@ -31,7 +31,7 @@ class ValidateManifest
         if (Manifest::shouldSeparateVendor($this->environment)) {
             Helpers::warn(
                 '- The "separate-vendor" option is deprecated.'
-                .' Please use docker based deployments instead:'
+                .' Please use Docker based deployments instead:'
                 .' https://docs.vapor.build/1.0/projects/environments.html#building-custom-docker-images'
             );
         }

--- a/src/BuildProcess/ValidateManifest.php
+++ b/src/BuildProcess/ValidateManifest.php
@@ -32,7 +32,7 @@ class ValidateManifest
             Helpers::warn(
                 '- The "separate-vendor" option is deprecated.'
                 .' Please use docker based deployments instead:'
-                .' https://docs.vapor.build/1.0/projects/environments.html#runtime'
+                .' https://docs.vapor.build/1.0/projects/environments.html#building-custom-docker-images'
             );
         }
 

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -21,6 +21,7 @@ use Laravel\VaporCli\BuildProcess\ProcessAssets;
 use Laravel\VaporCli\BuildProcess\RemoveIgnoredFiles;
 use Laravel\VaporCli\BuildProcess\RemoveVendorPlatformCheck;
 use Laravel\VaporCli\BuildProcess\SetBuildEnvironment;
+use Laravel\VaporCli\BuildProcess\ValidateManifest;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Manifest;
 use Laravel\VaporCli\Path;
@@ -62,6 +63,7 @@ class BuildCommand extends Command
         $startedAt = new DateTime();
 
         collect([
+            new ValidateManifest($this->argument('environment')),
             new CopyApplicationToBuildPath(),
             new HarmonizeConfigurationFiles(),
             new SetBuildEnvironment($this->argument('environment'), $this->option('asset-url')),

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -113,6 +113,18 @@ class Helpers
     }
 
     /**
+     * Display a warning message.
+     *
+     * @param string $text
+     *
+     * @return void
+     */
+    public static function warn($text)
+    {
+        static::app('output')->writeln('<fg=yellow>'.$text.'</>');
+    }
+
+    /**
      * Ensure that the user has authenticated with Laravel Vapor.
      *
      * @return void


### PR DESCRIPTION
This pull request adds a step that validates the manifest file. At this time, the only thing it does is warning the user about deprecated options:

<img width="1072" alt="Screenshot 2021-01-21 at 14 19 58" src="https://user-images.githubusercontent.com/5457236/105363288-c7ab3980-5bf3-11eb-8adc-c01400877288.png">
