### PR TITLE
Replaced npm prod with with production

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -135,7 +135,7 @@ class Manifest
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                         'php artisan event:cache',
-                        'npm ci && npm run prod && rm -rf node_modules',
+                        'npm ci && npm run production && rm -rf node_modules',
                     ],
                 ]),
                 'staging' => array_filter([


### PR DESCRIPTION
When i deploy to staging it all works perfectly, but to prod i get this:
```==> Running Command: npm ci && npm run prod && rm -rf node_modules
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.
npm WARN deprecated axios@0.18.1: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410
npm WARN deprecated popper.js@1.16.1: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1

added 1115 packages, and audited 1550 packages in 19s

48 packages are looking for funding
  run `npm fund` for details

7 vulnerabilities (3 low, 4 high)

To address all issues (including breaking changes), run:
  npm audit fix --force

Run `npm audit` for details.
npm ERR! missing script: prod

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/necenzurat/.npm/_logs/2021-01-31T14_34_54_314Z-debug.log

In Process.php line 267:
                                                                                                                                                          
  The command "npm ci && npm run prod && rm -rf node_modules" failed.                                                                                     
                                                                                                                                                          
  Exit Code: 1(General error)                                                                                                                             
                                                                                                                                                          
  Working directory: /Users/necenzurat/Apps/webkit.ro/.vapor/build/app                                                                                    
                                                                                                                                                          
  Output:                                                                                                                                                 
  ================                                                                                                                                        
                                                                                                                                                          
  added 1115 packages, and audited 1550 packages in 19s                                                                                                   
                                                                                                                                                          
  48 packages are looking for funding                                                                                                                     
    run `npm fund` for details                                                                                                                            
                                                                                                                                                          
  7 vulnerabilities (3 low, 4 high)                                                                                                                       
                                                                                                                                                          
  To address all issues (including breaking changes), run:                                                                                                
    npm audit fix --force                                                                                                                                 
                                                                                                                                                          
  Run `npm audit` for details.                                                                                                                            
                                                                                                                                                          
                                                                                                                                                          
  Error Output:                                                                                                                                           
  ================                                                                                                                                        
  npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated                                                                    
  npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated                                                                 
  npm WARN deprecated fsevents@1.2.13: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.                    
  npm WARN deprecated chokidar@2.1.8: Chokidar 2 will break on node v14+. Upgrade to chokidar 3 with 15x less dependencies.                               
  npm WARN deprecated axios@0.18.1: Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410  
  npm WARN deprecated popper.js@1.16.1: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1                      
  npm ERR! missing script: prod                                                                                                                           
                                                                                                                                                          
  npm ERR! A complete log of this run can be found in:                                                                                                    
  npm ERR!     /Users/necenzurat/.npm/_logs/2021-01-31T14_34_54_314Z-debug.log```

it seems that somewhere npm run prod vanishes. it's the only fix i could find.