### PR TITLE
Uses Amazon Linux 2 by default

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -131,7 +131,7 @@ class Manifest
                 'production' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-7.4',
+                    'runtime'    => 'php-7.4:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                         'php artisan event:cache',
@@ -141,7 +141,7 @@ class Manifest
                 'staging' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-7.4',
+                    'runtime'    => 'php-7.4:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install',
                         'php artisan event:cache',


### PR DESCRIPTION
Now that Vapor supports docker in all regions, we can start using Amazon Linux 2 by default in all new projects.