### PR TITLE
Add option to exclude node_modules folder from deploy

### DIFF
--- a/src/ApplicationFiles.php
+++ b/src/ApplicationFiles.php
@@ -20,7 +20,6 @@ class ApplicationFiles
                 ->exclude('.idea')
                 ->exclude('.vapor')
                 ->notPath('/^'.preg_quote('tests', '/').'/')
-                ->exclude('node_modules')
                 ->ignoreVcs(true)
                 ->ignoreDotFiles(false);
     }

--- a/src/BuildProcess/CopyApplicationToBuildPath.php
+++ b/src/BuildProcess/CopyApplicationToBuildPath.php
@@ -4,6 +4,7 @@ namespace Laravel\VaporCli\BuildProcess;
 
 use Laravel\VaporCli\ApplicationFiles;
 use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
 use SplFileInfo;
 
 class CopyApplicationToBuildPath
@@ -21,7 +22,7 @@ class CopyApplicationToBuildPath
 
         $this->ensureBuildDirectoryExists();
 
-        foreach (ApplicationFiles::get($this->path) as $file) {
+        foreach ($this->getApplicationFiles() as $file) {
             if ($file->isLink()) {
                 continue;
             }
@@ -33,6 +34,25 @@ class CopyApplicationToBuildPath
 
         $this->flushCacheFiles();
         $this->flushStorageDirectories();
+    }
+
+    /**
+     * Get the included application files.
+     *
+     * @return \Symfony\Component\Finder\Finder
+     * @throws \Symfony\Component\Finder\Exception\DirectoryNotFoundException
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     * @throws \Symfony\Component\Yaml\Exception\ParseException
+     */
+    public function getApplicationFiles()
+    {
+        $files = ApplicationFiles::get($this->path);
+
+        if (Manifest::excludeNodeModules()) {
+            $files->exclude('node_modules');
+        }
+
+        return $files;
     }
 
     /**

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -74,7 +74,11 @@ class Manifest
      */
     public static function excludeNodeModules()
     {
-        return static::current()['exclude-node-modules'] ?? true;
+        if (isset(static::current()['exclude-node-modules'])) {
+            return static::current()['exclude-node-modules'];
+        }
+
+        return true;
     }
 
     /**

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -68,6 +68,16 @@ class Manifest
     }
 
     /**
+     * Determine if we should exclude the node_modules directory.
+     *
+     * @return bool
+     */
+    public static function excludeNodeModules()
+    {
+        return static::current()['exclude-node-modules'] ?? true;
+    }
+
+    /**
      * Determine if we should separate the vendor directory.
      *
      * @param  string  $environment


### PR DESCRIPTION
Hi there,

So this is my proposal as we're struggling integrating many stuff that was and still required on our CI (Gitlab), and there is where we're doing the deployments using Vapor CLI.

This will solve a problem we've caching the node_modules folder on our CI (from another job that does more things like authenticate to private NPM repositories, etc).

### TL;DR

Don't remove the _node_modules_ folder before entering the Vapor's build hook, instead, ignore it after or let users decide on it (e.g. using the ignore on their _vapor.yml_ files as it excludes just before the deploy process).

I know this is a possible break change but if there's another possible solution we'll be very grateful.