### PR TITLE
Sets php 8 as default runtime

### DIFF
--- a/src/Commands/EnvCommand.php
+++ b/src/Commands/EnvCommand.php
@@ -40,12 +40,16 @@ class EnvCommand extends Command
             $this->option('docker')
         );
 
-        Manifest::addEnvironment($environment,
-            ! $this->option('docker') ? [] : [
-                'runtime' => 'docker',
-                'build' => ['COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev'],
-            ]
-        );
+        Manifest::addEnvironment($environment, [
+            'memory'     => 1024,
+            'cli-memory' => 512,
+            'runtime'    => $this->option('docker') ? 'docker' : 'php-8.0:al2',
+            'build'      => [
+                'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
+                'php artisan event:cache',
+                'npm ci && npm run prod && rm -rf node_modules',
+            ],
+        ]);
 
         if ($this->option('docker')) {
             Dockerfile::fresh($environment);

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -158,7 +158,7 @@ class Manifest
                 'production' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-7.4:al2',
+                    'runtime'    => 'php-8.0:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                         'php artisan event:cache',
@@ -168,7 +168,7 @@ class Manifest
                 'staging' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-7.4:al2',
+                    'runtime'    => 'php-8.0:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install',
                         'php artisan event:cache',


### PR DESCRIPTION
This pull request sets "php-8.0:al2" as default runtime, and modifies the default template for new environments created with the command "vapor env" to make them more similar to default environments in Vapor.