### PR TITLE
Delete possible .dockerignore file from build path

### DIFF
--- a/src/BuildProcess/CopyApplicationToBuildPath.php
+++ b/src/BuildProcess/CopyApplicationToBuildPath.php
@@ -34,6 +34,7 @@ class CopyApplicationToBuildPath
 
         $this->flushCacheFiles();
         $this->flushStorageDirectories();
+        $this->removePossibleDockerignoreFile();
     }
 
     /**
@@ -127,5 +128,15 @@ class CopyApplicationToBuildPath
         $this->files->deleteDirectory($path.'/storage/framework/views', true);
         $this->files->deleteDirectory($path.'/storage/framework/testing', true);
         $this->files->deleteDirectory($path.'/storage/framework/sessions', true);
+    }
+
+    /**
+     * Delete a possible .dockerignore file that might exclude required files or directories.
+     *
+     * @return void
+     */
+    protected function removePossibleDockerignoreFile()
+    {
+        $this->files->delete($this->appPath.'/.dockerignore');
     }
 }


### PR DESCRIPTION
A user might be using Docker for other things as well.\
If he has a `.dockerignore` file that excludes the `vendor/` directory this breaks builds with the following error:

`Fatal error: require(): Failed opening required '/var/task/vendor/autoload.php' (include_path='.:/usr/local/lib/php') in /var/task/runtime.php on line 13`

This scenario is very unlikely but can be prevented by deleting a possibly existing .dockerignore file.
The PR adds the deletion to the `CopyApplicationToBuildPath` class.