### PR TITLE
Uses PHP 8 in docker files by default

### DIFF
--- a/src/Dockerfile.php
+++ b/src/Dockerfile.php
@@ -13,7 +13,7 @@ class Dockerfile
     public static function fresh($environment)
     {
         $content = <<<'Dockerfile'
-FROM laravelphp/vapor:php74
+FROM laravelphp/vapor:php80
 
 COPY . /var/task
 Dockerfile;


### PR DESCRIPTION
This pull request makes the docker files created to use PHP 8 by default.