### PR TITLE
Adds Redis 6 support

### DIFF
--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -44,16 +44,31 @@ class CacheCommand extends Command
         }
 
         $instanceClass = $this->determineInstanceClass();
+        $type = $this->determineCacheType();
 
         $response = $this->vapor->createCache(
             $networkId,
             $this->argument('name'),
+            $type,
             $instanceClass
         );
 
         Helpers::info('Cache creation initiated successfully.');
         Helpers::line();
         Helpers::line('Caches may take several minutes to finish provisioning.');
+    }
+
+    /**
+     * Determine the cache type.
+     *
+     * @return string
+     */
+    protected function determineCacheType()
+    {
+        return $this->menu('Which type of cache would you like to create?', [
+            'redis6.x-cluster' => 'Redis 6.x Cluster',
+            'redis-cluster'    => 'Redis 5.x Cluster',
+        ]);
     }
 
     /**

--- a/src/Commands/CacheListCommand.php
+++ b/src/Commands/CacheListCommand.php
@@ -29,17 +29,28 @@ class CacheListCommand extends Command
         Helpers::ensure_api_token_is_available();
 
         $this->table([
-            'ID', 'Provider', 'Name', 'Region', 'Class', 'Scale', 'Status',
+            'ID', 'Provider', 'Name', 'Region', 'Type', 'Class', 'Scale', 'Status',
         ], collect($this->vapor->caches())->map(function ($cache) {
             return [
                 $cache['id'],
                 $cache['cloud_provider']['name'],
                 $cache['name'],
                 $cache['region'],
+                $this->cacheType($cache['type']),
                 $cache['instance_class'],
                 $cache['scale'],
                 Str::title(str_replace('_', ' ', $cache['status'])),
             ];
         })->all());
+    }
+
+    /**
+     * The cache type.
+     *
+     * @return string
+     */
+    protected function cacheType($type)
+    {
+        return $type == 'redis6.x-cluster' ? 'Redis 6.x Cluster' : 'Redis 5.x Cluster';
     }
 }

--- a/src/Commands/CacheListCommand.php
+++ b/src/Commands/CacheListCommand.php
@@ -45,7 +45,7 @@ class CacheListCommand extends Command
     }
 
     /**
-     * The cache type.
+     * Get the displayable cache type.
      *
      * @return string
      */

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -589,14 +589,16 @@ class ConsoleVaporClient
      *
      * @param string $networkId
      * @param string $name
+     * @param string $type
      * @param string $instanceClass
      *
      * @return array
      */
-    public function createCache($networkId, $name, $instanceClass)
+    public function createCache($networkId, $name, $type, $instanceClass)
     {
         return $this->requestWithErrorHandling('post', '/api/networks/'.$networkId.'/caches', [
             'name'           => $name,
+            'type'           => $type,
             'instance_class' => $instanceClass,
         ]);
     }


### PR DESCRIPTION
This pull request adds support for Redis 6.

1. First, when creating a new cache using the command `cache`, you now get the "type" question:
<img width="703" alt="type" src="https://user-images.githubusercontent.com/5457236/117013105-77aa3b80-ace7-11eb-8916-c2d8325a8359.png">

2. Next, the list also now presents the type of cache:
<img width="909" alt="list" src="https://user-images.githubusercontent.com/5457236/117013141-809b0d00-ace7-11eb-95d3-a869a6039aad.png">
