### PR TITLE
Allow forcing asset re-uploading

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -32,6 +32,7 @@ class DeployCommand extends Command
             ->addOption('commit', null, InputOption::VALUE_OPTIONAL, 'The commit hash that is being deployed')
             ->addOption('message', null, InputOption::VALUE_OPTIONAL, 'The message for the commit that is being deployed')
             ->addOption('without-waiting', null, InputOption::VALUE_NONE, 'Deploy without waiting for progress')
+            ->addOption('fresh-assets', null, InputOption::VALUE_NONE, 'Upload a fresh copy from all assets')
             ->setDescription('Deploy an environment');
     }
 
@@ -202,7 +203,7 @@ class DeployCommand extends Command
     {
         Helpers::line();
 
-        (new ServeAssets())->__invoke($this->vapor, $artifact);
+        (new ServeAssets())->__invoke($this->vapor, $artifact, $this->option('fresh-assets'));
     }
 
     /**

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -32,7 +32,7 @@ class DeployCommand extends Command
             ->addOption('commit', null, InputOption::VALUE_OPTIONAL, 'The commit hash that is being deployed')
             ->addOption('message', null, InputOption::VALUE_OPTIONAL, 'The message for the commit that is being deployed')
             ->addOption('without-waiting', null, InputOption::VALUE_NONE, 'Deploy without waiting for progress')
-            ->addOption('fresh-assets', null, InputOption::VALUE_NONE, 'Upload a fresh copy from all assets')
+            ->addOption('fresh-assets', null, InputOption::VALUE_NONE, 'Upload a fresh copy of all assets')
             ->setDescription('Deploy an environment');
     }
 

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1042,13 +1042,15 @@ class ConsoleVaporClient
      *
      * @param int   $artifactId
      * @param array $files
+     * @param  bool  $fresh
      *
      * @return array
      */
-    public function authorizeArtifactAssets($artifactId, array $files)
+    public function authorizeArtifactAssets($artifactId, array $files, bool $fresh = false)
     {
         return $this->requestWithErrorHandling('post', '/api/artifacts/'.$artifactId.'/asset-authorizations', [
             'files' => $files,
+            'fresh' => $fresh
         ]);
     }
 

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1050,7 +1050,7 @@ class ConsoleVaporClient
     {
         return $this->requestWithErrorHandling('post', '/api/artifacts/'.$artifactId.'/asset-authorizations', [
             'files' => $files,
-            'fresh' => $fresh
+            'fresh' => $fresh,
         ]);
     }
 

--- a/src/ServeAssets.php
+++ b/src/ServeAssets.php
@@ -11,17 +11,19 @@ class ServeAssets
      *
      * @param \Laravel\VaporCli\ConsoleVaporClient $vapor
      * @param array                                $artifact
+     * @param bool                                $fresh
      *
      * @return void
      */
-    public function __invoke(ConsoleVaporClient $vapor, array $artifact)
+    public function __invoke(ConsoleVaporClient $vapor, array $artifact, $fresh)
     {
         $assetPath = Path::build().'/assets';
 
         $requests = $this->getAuthorizedAssetRequests(
             $vapor,
             $artifact,
-            $assetFiles = $this->getAssetFiles($assetPath)
+            $assetFiles = $this->getAssetFiles($assetPath),
+            $fresh
         );
 
         $this->executeStoreAssetRequests($requests['store'], $assetPath);
@@ -72,7 +74,9 @@ class ServeAssets
             Helpers::step('<fg=magenta>Copying Unchanged Asset:</> '.$request['path'].' ('.Helpers::kilobytes($assetPath.'/'.$request['path']).')');
         }
 
-        $storage->executeCopyRequests($requests);
+        if (! empty($requests)) {
+            $storage->executeCopyRequests($requests);
+        }
     }
 
     /**
@@ -87,11 +91,13 @@ class ServeAssets
     protected function getAuthorizedAssetRequests(
         ConsoleVaporClient $vapor,
         array $artifact,
-        array $assetFiles
+        array $assetFiles,
+        bool $fresh
     ) {
         return $vapor->authorizeArtifactAssets(
             $artifact['id'],
-            $assetFiles
+            $assetFiles,
+            $fresh
         );
     }
 


### PR DESCRIPTION
Using a `--fresh-assets` option on the `vapor deploy` command will force all assets to be re-uploaded.