### PR TITLE
Displays message when DNS records change

### DIFF
--- a/src/Commands/Output/DeploymentSuccess.php
+++ b/src/Commands/Output/DeploymentSuccess.php
@@ -71,7 +71,7 @@ class DeploymentSuccess
         })->each(function ($zone) {
             $zone = $zone['zone'];
 
-            Helpers::line("The DNS records of the zone <comment>$zone</comment> have changed in the last week. If you self-manage the DNS settings of this zone, please run <comment>vapor record:list $zone</comment>, and update the DNS settings of the domain accordingly.");
+            Helpers::line("The DNS records of the zone <comment>$zone</comment> have changed in the last week. If you self-manage the DNS settings of this zone, please run <comment>vapor record:list $zone</comment> and update the DNS settings of the domain accordingly.");
         });
     }
 }

--- a/src/Commands/Output/DeploymentSuccess.php
+++ b/src/Commands/Output/DeploymentSuccess.php
@@ -4,6 +4,8 @@ namespace Laravel\VaporCli\Commands\Output;
 
 use DateTime;
 use DateTimeInterface;
+use Illuminate\Support\Carbon;
+use Laravel\VaporCli\ConsoleVaporClient;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Models\Deployment;
 
@@ -25,7 +27,7 @@ class DeploymentSuccess
         Helpers::line("<info>Project deployed successfully.</info> ({$time})");
 
         if ($deployment->hasTargetDomains()) {
-            $this->displayTargetDomains($deployment);
+            $this->displayDnsRecordsChanges($deployment);
         }
 
         if ($deployment->vanityDomain()) {
@@ -42,13 +44,13 @@ class DeploymentSuccess
     }
 
     /**
-     * Display the target domains for the deployment domains.
+     * Display the DNS Records changes related to this environment.
      *
      * @param \Laravel\VaporCli\Models\Deployment $deployment
      *
      * @return void
      */
-    protected function displayTargetDomains(Deployment $deployment)
+    protected function displayDnsRecordsChanges(Deployment $deployment)
     {
         Helpers::line();
 
@@ -58,10 +60,18 @@ class DeploymentSuccess
             Helpers::line();
         }
 
-        Helpers::table([
-            'Domain', 'Alias / CNAME',
-        ], collect($deployment->target_domains)->map(function ($target, $domain) {
-            return [$domain, $target['domain']];
-        })->all());
+        $vapor = Helpers::app(ConsoleVaporClient::class);
+
+        collect($vapor->zones())->filter(function ($zone) use ($deployment) {
+            return in_array($zone['zone'], $deployment->root_domains);
+        })->filter(function ($zone) use ($vapor) {
+            return collect($vapor->records($zone['id']))->contains(function ($zone) {
+                return Carbon::parse($zone['updated_at'])->greaterThanOrEqualTo(Carbon::now()->subWeek());
+            });
+        })->each(function ($zone) {
+            $zone = $zone['zone'];
+
+            Helpers::line("The DNS records of the zone <comment>$zone</comment> have changed in the last week. If you self-manage the DNS settings of this zone, please run <comment>vapor record:list $zone</comment>, and update the DNS settings of the domain accordingly.");
+        });
     }
 }

--- a/src/Commands/Output/DeploymentSuccess.php
+++ b/src/Commands/Output/DeploymentSuccess.php
@@ -65,8 +65,8 @@ class DeploymentSuccess
         collect($vapor->zones())->filter(function ($zone) use ($deployment) {
             return in_array($zone['zone'], $deployment->root_domains);
         })->filter(function ($zone) use ($vapor) {
-            return collect($vapor->records($zone['id']))->contains(function ($zone) {
-                return Carbon::parse($zone['updated_at'])->greaterThanOrEqualTo(Carbon::now()->subWeek());
+            return collect($vapor->records($zone['id']))->contains(function ($record) {
+                return Carbon::parse($record['updated_at'])->greaterThanOrEqualTo(Carbon::now()->subWeek());
             });
         })->each(function ($zone) {
             $zone = $zone['zone'];


### PR DESCRIPTION
When customers self-manage DNS records on Vapor, often DNS records may change because customers may attach a load balancer or just active their mail (SES service) using Vapor.

This pull request adds a message during deployments that warn the customers when they need to update their DNS settings. This message will appear if the DNS records have been changed once in the last week.

<img width="1027" alt="Screenshot 2021-05-12 at 13 56 11" src="https://user-images.githubusercontent.com/5457236/117978462-d136e980-b329-11eb-80c1-adb1937675bc.png">
