### PR TITLE
Adds Team ID to team:list command

### DIFF
--- a/src/Commands/TeamListCommand.php
+++ b/src/Commands/TeamListCommand.php
@@ -39,9 +39,10 @@ class TeamListCommand extends Command
         })->all();
 
         $this->table([
-            'Name', 'Owner',
+            'ID', 'Name', 'Owner',
         ], collect($allTeams)->map(function ($team) use ($user) {
             return [
+                $team['id'],
                 $team['name'],
                 $team['owner']['id'] === $user['id']
                                 ? 'You'


### PR DESCRIPTION
This pull request adds the team `id` to the `team:list` CLI command.