### PR TITLE
Fixes "undefined index level_name"

### DIFF
--- a/src/Commands/TailCommand.php
+++ b/src/Commands/TailCommand.php
@@ -155,7 +155,7 @@ class TailCommand extends Command
 
             $message = json_decode($message, true);
 
-            if ($message && ! empty($message)) {
+            if ($message && ! empty($message) && ! empty($message['level_name'])) {
                 $this->displayMessage($message);
             }
         }


### PR DESCRIPTION
This pull request avoids that Vapor CLI attemps to log JSON messages that are not application logs.