### PR TITLE
feat: manifest path option

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Laravel\VaporCli;
+
+use Symfony\Component\Console\Application as SymfonyConsoleApplication;
+use Symfony\Component\Console\Input\InputOption;
+
+class Application extends SymfonyConsoleApplication
+{
+    protected function getDefaultInputDefinition()
+    {
+        $definition = parent::getDefaultInputDefinition();
+        $definition->addOption(new InputOption('manifest', null, InputOption::VALUE_OPTIONAL, 'Path to your vapor manifest'));
+
+        return $definition;
+    }
+}

--- a/src/Application.php
+++ b/src/Application.php
@@ -10,7 +10,8 @@ class Application extends SymfonyConsoleApplication
     protected function getDefaultInputDefinition()
     {
         $definition = parent::getDefaultInputDefinition();
-        $definition->addOption(new InputOption('manifest', null, InputOption::VALUE_OPTIONAL, 'Path to your vapor manifest'));
+
+        $definition->addOption(new InputOption('manifest', null, InputOption::VALUE_OPTIONAL, 'The path to your Vapor.yml manifest'));
 
         return $definition;
     }

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -3,8 +3,10 @@
 namespace Laravel\VaporCli\Commands;
 
 use DateTime;
+use Illuminate\Container\Container;
 use Laravel\VaporCli\ConsoleVaporClient;
 use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Path;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -67,6 +69,7 @@ class Command extends SymfonyCommand
         Helpers::app()->instance('input', $this->input = $input);
         Helpers::app()->instance('output', $this->output = $output);
 
+        $this->configureManifestPath($input);
         $this->configureOutputStyles($output);
 
         return Helpers::app()->call([$this, 'handle']) ?: 0;
@@ -85,6 +88,18 @@ class Command extends SymfonyCommand
             'finished',
             new OutputFormatterStyle('green', 'default', ['bold'])
         );
+    }
+
+    /**
+     * Configure manifest style location
+     *
+     * @param InputInterface $input
+     *
+     * @return void
+     */
+    protected function configureManifestPath(InputInterface $input)
+    {
+        Helpers::app()->offsetSet('manifest', $input->getOption('manifest') ?? Path::defaultManifest());
     }
 
     /**

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -3,7 +3,6 @@
 namespace Laravel\VaporCli\Commands;
 
 use DateTime;
-use Illuminate\Container\Container;
 use Laravel\VaporCli\ConsoleVaporClient;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Path;
@@ -91,7 +90,7 @@ class Command extends SymfonyCommand
     }
 
     /**
-     * Configure manifest style location
+     * Configure manifest style location.
      *
      * @param InputInterface $input
      *

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -104,6 +104,7 @@ class DeployCommand extends Command
         $this->call('build', [
             'environment' => $this->argument('environment'),
             '--asset-url' => $this->assetDomain($project).'/'.$uuid,
+            '--manifest' => Path::manifest(),
         ]);
 
         return $this->uploadArtifact(

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -34,7 +34,7 @@ class Manifest
     public static function current()
     {
         if (! file_exists(Path::manifest())) {
-            Helpers::abort('Unable to find a Vapor manifest in this directory.');
+            Helpers::abort(sprintf('Unable to find a Vapor manifest at %s.', Path::manifest()));
         }
 
         return Yaml::parse(file_get_contents(Path::manifest()));

--- a/src/Path.php
+++ b/src/Path.php
@@ -81,6 +81,16 @@ class Path
      */
     public static function manifest()
     {
+        return Helpers::app('manifest');
+    }
+
+    /**
+     * Get the path to the project's default manifest file.
+     *
+     * @return string
+     */
+    public static function defaultManifest()
+    {
         return getcwd().'/vapor.yml';
     }
 

--- a/vapor
+++ b/vapor
@@ -9,8 +9,8 @@ use Dotenv\Repository\Adapter\EnvConstAdapter as V4orV5EnvConstAdapter;
 use Dotenv\Repository\Adapter\ServerConstAdapter as V4orV5ServerConstAdapter;
 use Dotenv\Repository\RepositoryBuilder;
 use Illuminate\Container\Container;
+use Laravel\VaporCli\Application;
 use Laravel\VaporCli\Commands;
-use Symfony\Component\Console\Application;
 
 /**
  * Require the autoloader.


### PR DESCRIPTION
Basically, we need to have multiple manifest files in the same project. Currently the CLI forces us to use a single hardcoded file.

This PR allows that file to be configured using a default option on all commands, falling back to the previous hard coded value.

Changes are:
- Extend the default symfony console app to add an additional default option (--manifest)
- Update the command execute method to load the file path from the `--manifest` option into the container (if set, otherwise default)
- Update the `Path` class to grab the manifest path from the container instead of hardcoded value.