### PR TITLE
feat: specify filename when pulling/pushing env files

### DIFF
--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -18,6 +18,7 @@ class EnvPullCommand extends Command
         $this
             ->setName('env:pull')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('file', InputArgument::OPTIONAL, 'File to write the environment variables to')
             ->setDescription('Download the environment file for the given environment');
     }
 
@@ -34,14 +35,16 @@ class EnvPullCommand extends Command
 
         Helpers::step('<options=bold>Downloading Environment File...</>');
 
+        $file = $this->option('file') ?? getcwd().'/.env.'.$environment;
+
         file_put_contents(
-            getcwd().'/.env.'.$environment,
+            $file,
             trim($this->vapor->environmentVariables(
                 Manifest::id(),
                 $environment
             )).PHP_EOL
         );
 
-        Helpers::info(PHP_EOL."Environment variables written to [./.env.{$environment}].");
+        Helpers::info(PHP_EOL."Environment variables written to [{$file}].");
     }
 }

--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -35,7 +35,7 @@ class EnvPullCommand extends Command
 
         Helpers::step('<options=bold>Downloading Environment File...</>');
 
-        $file = $this->option('file') ?? getcwd().'/.env.'.$environment;
+        $file = $this->option('file') ?: getcwd().'/.env.'.$environment;
 
         file_put_contents(
             $file,

--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -18,7 +18,7 @@ class EnvPullCommand extends Command
         $this
             ->setName('env:pull')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('file', InputArgument::OPTIONAL, 'File to write the environment variables to')
+            ->addOption('file', null, InputArgument::OPTIONAL, 'File to write the environment variables to')
             ->setDescription('Download the environment file for the given environment');
     }
 

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -33,7 +33,7 @@ class EnvPushCommand extends Command
 
         $environment = $this->argument('environment');
 
-        $file = $this->option('file') ?? getcwd().'/.env.'.$environment;
+        $file = $this->option('file') ?: getcwd().'/.env.'.$environment;
 
         if (! file_exists($file)) {
             Helpers::abort('The environment variables for that environment have not been downloaded.');

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -18,6 +18,7 @@ class EnvPushCommand extends Command
         $this
             ->setName('env:push')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('file', InputArgument::OPTIONAL, 'File to upload the environment variables from')
             ->setDescription('Upload the environment file for the given environment');
     }
 
@@ -32,7 +33,9 @@ class EnvPushCommand extends Command
 
         $environment = $this->argument('environment');
 
-        if (! file_exists($file = getcwd().'/.env.'.$environment)) {
+        $file = $this->option('file') ?? getcwd().'/.env.'.$environment;
+
+        if (! file_exists($file)) {
             Helpers::abort('The environment variables for that environment have not been downloaded.');
         }
 

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -18,7 +18,7 @@ class EnvPushCommand extends Command
         $this
             ->setName('env:push')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('file', InputArgument::OPTIONAL, 'File to upload the environment variables from')
+            ->addOption('file', null, InputArgument::OPTIONAL, 'File to upload the environment variables from')
             ->setDescription('Upload the environment file for the given environment');
     }
 


### PR DESCRIPTION
We use a custom naming scheme for our .env files (as we deploy multiple vapor environments from the same codebase).

It looks like `.env.vapor.{brand}.{stage}`

This PR allows you to pass a custom filename when pulling/pushing .env files. No changes to existing behaviour, it defaults to the current behaviour :)