### PR TITLE
Removes cached routes before deploying

### DIFF
--- a/src/BuildProcess/CopyApplicationToBuildPath.php
+++ b/src/BuildProcess/CopyApplicationToBuildPath.php
@@ -111,6 +111,12 @@ class CopyApplicationToBuildPath
     protected function flushCacheFiles()
     {
         $this->files->delete($this->appPath.'/bootstrap/cache/config.php');
+
+        $this->files->delete(
+            $this->files->glob(
+                $this->appPath.'/bootstrap/cache/routes*.php'
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
This pull request addresses an issue when people locally perform "php artisan routes:cache", and deploy their application after that. The result, will be an exception on their Vapor environment with the following message: `{"message":"Your serialized closure might have been modified and it's unsafe to be unserialized. Make sure you use the same security provider, with the same settings, both for serialization and unserialization.","context":{"exception":{"class":"Opis\\Closure\\SecurityException","message":"Your`.

This pull request uses a `glob` so the code is compatibly with Laravel 6, 7, and 8.