### PR TITLE
Adds possibility of run again commands

### DIFF
--- a/src/Commands/CommandAgainCommand.php
+++ b/src/Commands/CommandAgainCommand.php
@@ -2,10 +2,11 @@
 
 namespace Laravel\VaporCli\Commands;
 
+use Laravel\VaporCli\Commands\Output\CommandResult;
 use Laravel\VaporCli\Helpers;
 use Symfony\Component\Console\Input\InputArgument;
 
-class CommandReRunCommand extends Command
+class CommandAgainCommand extends Command
 {
     /**
      * Configure the command options.
@@ -15,9 +16,9 @@ class CommandReRunCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('command:re-run')
+            ->setName('command:again')
             ->addArgument('id', InputArgument::OPTIONAL, 'The command ID')
-            ->setDescription('Re-execute a CLI command');
+            ->setDescription('Runs again a CLI command');
     }
 
     /**
@@ -42,12 +43,14 @@ class CommandReRunCommand extends Command
         Helpers::line('<fg=magenta>Vapor Command: </>php artisan '.$command['command']);
         Helpers::line('<fg=magenta>Vapor Command ID:</> '.$command['id']);
         Helpers::line('<fg=magenta>Vapor Environment:</> '.$environment['name']);
+        Helpers::line('<fg=magenta>Vapor Project:</> '.$environment['project']['name']);
 
-        if (Helpers::confirm('Are you sure you want to re-run this command?', true)) {
-            return $this->call('command', [
-                'environment' => $environment['name'],
-                '--command' => $command['command'],
-            ]);
+        if (! Helpers::confirm('Are you sure you want to run again this command?', true)) {
+            return 0;
         }
+
+        $command = $this->vapor->commandReRun($command['id']);
+
+        (new CommandResult)->render($command);
     }
 }

--- a/src/Commands/CommandAgainCommand.php
+++ b/src/Commands/CommandAgainCommand.php
@@ -18,7 +18,7 @@ class CommandAgainCommand extends Command
         $this
             ->setName('command:again')
             ->addArgument('id', InputArgument::OPTIONAL, 'The command ID')
-            ->setDescription('Runs again a CLI command');
+            ->setDescription('Re-execute a CLI command');
     }
 
     /**

--- a/src/Commands/CommandCommand.php
+++ b/src/Commands/CommandCommand.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\VaporCli\Commands;
 
+use Laravel\VaporCli\Commands\Output\CommandResult;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Manifest;
 use Symfony\Component\Console\Input\InputArgument;
@@ -41,22 +42,7 @@ class CommandCommand extends Command
             $this->getCommand()
         );
 
-        Helpers::step('<options=bold>Executing Function...</>'.PHP_EOL);
-
-        // We will poll the backend service to get the invocations status and wait until
-        // it gets done processing. Once it's done we will be able to show the status
-        // of the invocation and any related logs which will need to get displayed.
-        $command = $this->waitForCommandToFinish($command);
-
-        $this->displayStatusCode($command);
-
-        $this->displayOutput($command);
-
-        Helpers::line();
-        Helpers::line('<fg=magenta>Vapor Command ID:</> '.$command['id']);
-        Helpers::line('<fg=magenta>AWS Request ID:</> '.$command['request_id']);
-        Helpers::line('<fg=magenta>AWS Log Group Name:</> '.$command['log_group']);
-        Helpers::line('<fg=magenta>AWS Log Stream Name:</> '.$command['log_stream']);
+        (new CommandResult)->render($command);
     }
 
     /**
@@ -67,85 +53,5 @@ class CommandCommand extends Command
     protected function getCommand()
     {
         return $this->option('command') ?? Helpers::ask('What command would you like to execute');
-    }
-
-    /**
-     * Wait for the given command to finish executing.
-     *
-     * @param array $command
-     *
-     * @return array
-     */
-    protected function waitForCommandToFinish(array $command)
-    {
-        while ($command['status'] !== 'finished') {
-            sleep(1);
-
-            $command = $this->vapor->command($command['id']);
-        }
-
-        return $command;
-    }
-
-    /**
-     * Display the status code of the command.
-     *
-     * @param array $command
-     *
-     * @return void
-     */
-    protected function displayStatusCode(array $command)
-    {
-        if (! isset($command['status_code'])) {
-            return;
-        }
-
-        $command['status_code'] === 0
-                ? Helpers::line('<finished>Status Code:</> 0')
-                : Helpers::line('<fg=red>Status Code:</> '.$command['status_code']);
-    }
-
-    /**
-     * Display the output of the command.
-     *
-     * @param array $command
-     *
-     * @return void
-     */
-    protected function displayOutput(array $command)
-    {
-        Helpers::line();
-
-        if (isset($command['output'])) {
-            Helpers::comment('Output:');
-
-            $output = $command['output'];
-            $output = base64_decode($output);
-
-            if ($json = json_decode($output, true)) {
-                $output = $json['output'];
-            }
-
-            Helpers::write($output);
-        }
-    }
-
-    /**
-     * Display the command's log messages.
-     *
-     * @param array $command
-     * @param int   $statusCode
-     *
-     * @return void
-     */
-    protected function displayLog(array $command, $statusCode)
-    {
-        if (! isset($command['output']) || $statusCode !== 0) {
-            Helpers::line();
-            Helpers::comment('Function Logs:');
-            Helpers::line();
-
-            Helpers::write(base64_decode($command['log']));
-        }
     }
 }

--- a/src/Commands/CommandReRunCommand.php
+++ b/src/Commands/CommandReRunCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Laravel\VaporCli\Helpers;
+use Symfony\Component\Console\Input\InputArgument;
+
+class CommandReRunCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('command:re-run')
+            ->addArgument('id', InputArgument::OPTIONAL, 'The command ID')
+            ->setDescription('Re-execute a CLI command');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Helpers::ensure_api_token_is_available();
+
+        $command = $this->vapor->command(
+            $this->argument('id') ?? $this->vapor->latestCommand()['id']
+        );
+
+        $environment = $this->vapor->environment(
+            $command['environment']['project_id'],
+            $command['environment']['id']
+        );
+
+        Helpers::line();
+        Helpers::line('<fg=magenta>Vapor Command: </>php artisan '.$command['command']);
+        Helpers::line('<fg=magenta>Vapor Command ID:</> '.$command['id']);
+        Helpers::line('<fg=magenta>Vapor Environment:</> '.$environment['name']);
+
+        if (Helpers::confirm('Are you sure you want to re-run this command?', true)) {
+            return $this->call('command', [
+                'environment' => $environment['name'],
+                '--command' => $command['command'],
+            ]);
+        }
+    }
+}

--- a/src/Commands/Output/CommandResult.php
+++ b/src/Commands/Output/CommandResult.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Laravel\VaporCli\Commands\Output;
+
+use Laravel\VaporCli\ConsoleVaporClient;
+use Laravel\VaporCli\Helpers;
+
+class CommandResult
+{
+    /**
+     * Render the output.
+     *
+     * @param  array  $output
+     *
+     * @return void
+     */
+    public function render($command)
+    {
+        Helpers::step('<options=bold>Executing Function...</>'.PHP_EOL);
+
+        // We will poll the backend service to get the invocations status and wait until
+        // it gets done processing. Once it's done we will be able to show the status
+        // of the invocation and any related logs which will need to get displayed.
+        $command = $this->waitForCommandToFinish($command);
+
+        $this->displayStatusCode($command);
+
+        $this->displayOutput($command);
+
+        Helpers::line();
+        Helpers::line('<fg=magenta>Vapor Command ID:</> '.$command['id']);
+        Helpers::line('<fg=magenta>AWS Request ID:</> '.$command['request_id']);
+        Helpers::line('<fg=magenta>AWS Log Group Name:</> '.$command['log_group']);
+        Helpers::line('<fg=magenta>AWS Log Stream Name:</> '.$command['log_stream']);
+    }
+
+    /**
+     * Wait for the given command to finish executing.
+     *
+     * @param array $command
+     *
+     * @return array
+     */
+    protected function waitForCommandToFinish($command)
+    {
+        while ($command['status'] !== 'finished') {
+            sleep(1);
+
+            $command = Helpers::app(ConsoleVaporClient::class)
+                ->command($command['id']);
+        }
+
+        return $command;
+    }
+
+    /**
+     * Display the status code of the command.
+     *
+     * @param array $command
+     *
+     * @return void
+     */
+    protected function displayStatusCode($command)
+    {
+        if (! isset($command['status_code'])) {
+            return;
+        }
+
+        $command['status_code'] === 0
+                ? Helpers::line('<finished>Status Code:</> 0')
+                : Helpers::line('<fg=red>Status Code:</> '.$command['status_code']);
+    }
+
+    /**
+     * Display the output of the command.
+     *
+     * @param array $command
+     *
+     * @return void
+     */
+    protected function displayOutput($command)
+    {
+        Helpers::line();
+
+        if (isset($command['output'])) {
+            Helpers::comment('Output:');
+
+            $output = $command['output'];
+            $output = base64_decode($output);
+
+            if ($json = json_decode($output, true)) {
+                $output = $json['output'];
+            }
+
+            Helpers::write($output);
+        }
+    }
+
+    /**
+     * Display the command's log messages.
+     *
+     * @param array $command
+     * @param int   $statusCode
+     *
+     * @return void
+     */
+    protected function displayLog($command, $statusCode)
+    {
+        if (! isset($command['output']) || $statusCode !== 0) {
+            Helpers::line();
+            Helpers::comment('Function Logs:');
+            Helpers::line();
+
+            Helpers::write(base64_decode($command['log']));
+        }
+    }
+}

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1294,6 +1294,18 @@ class ConsoleVaporClient
     }
 
     /**
+     * Re-runs the given command id.
+     *
+     * @param string $commandId
+     *
+     * @return array
+     */
+    public function commandReRun($commandId)
+    {
+        return $this->requestWithErrorHandling('post', '/api/commands/'.$commandId.'/re-run');
+    }
+
+    /**
      * Get all of the commands for the given project and environment.
      *
      * @param string $projectId

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -880,6 +880,22 @@ class ConsoleVaporClient
     }
 
     /**
+     * Get the environment with the given ID.
+     *
+     * @param string $projectId
+     * @param string $environmentId
+     *
+     * @return array
+     */
+    public function environment($projectId, $environmentId)
+    {
+        return $this->request(
+            'get',
+            '/api/projects/'.$projectId.'/environments/'.$environmentId
+        );
+    }
+
+    /**
      * Create a new environment for the project.
      *
      * @param  int  $projectId

--- a/vapor
+++ b/vapor
@@ -188,6 +188,7 @@ $app->add(new Commands\UpCommand);
 // Commands / Invocations...
 $app->add(new Commands\CommandCommand);
 $app->add(new Commands\CommandLogCommand);
+$app->add(new Commands\CommandReRunCommand);
 $app->add(new Commands\TinkerCommand);
 
 // Logs...

--- a/vapor
+++ b/vapor
@@ -188,7 +188,7 @@ $app->add(new Commands\UpCommand);
 // Commands / Invocations...
 $app->add(new Commands\CommandCommand);
 $app->add(new Commands\CommandLogCommand);
-$app->add(new Commands\CommandReRunCommand);
+$app->add(new Commands\CommandAgainCommand);
 $app->add(new Commands\TinkerCommand);
 
 // Logs...


### PR DESCRIPTION
This pull request adds the possibility of re-run commands directly from the Vapor CLI.

Note: Waiting for https://github.com/laravel/vapor/pull/233.

<img width="1146" alt="Screenshot 2021-06-23 at 15 54 50" src="https://user-images.githubusercontent.com/5457236/123119354-5b02c800-d43b-11eb-8dcd-2203dacd456c.png">