### PR TITLE
Proper escaping of tinker code

### DIFF
--- a/src/Commands/TinkerCommand.php
+++ b/src/Commands/TinkerCommand.php
@@ -31,6 +31,6 @@ class TinkerCommand extends CommandCommand
     {
         $code = $this->option('code') ?? Helpers::ask('What code would you like to execute');
 
-        return 'tinker --execute "'.$code.'"';
+        return 'tinker --execute '.escapeshellarg($code);
     }
 }


### PR DESCRIPTION
Problem:

Dollar signs ($) were not properly escaped in the code executed by `vapor tinker` command.
Essentially any code working with any variables like in this example:
```
$user = User::first(); $user->name = 'John'; $user->save();
```
had to be manually escaped to something like this:
```
\$user = User::first(); \$user->name = 'John'; \$user->save();
```

Solution:

Replace double quotes (") around the code that is sent to Lambda with `escapeshellarg()` which wraps the code in single quotes and escapes any single quotes inside preventing variable substitution by the shell 
