### PR TITLE
fix: allow keeping env

### DIFF
--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -19,7 +19,7 @@ class EnvPushCommand extends Command
             ->setName('env:push')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
             ->addOption('file', null, InputArgument::OPTIONAL, 'File to upload the environment variables from')
-            ->addOption('keep', null, InputArgument::OPTIONAL, 'Keep environment file after pushing')
+            ->addOption('keep', null, InputArgument::OPTIONAL, 'Keep the environment file after pushing')
             ->setDescription('Upload the environment file for the given environment');
     }
 

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -19,6 +19,7 @@ class EnvPushCommand extends Command
             ->setName('env:push')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
             ->addOption('file', null, InputArgument::OPTIONAL, 'File to upload the environment variables from')
+            ->addOption('keep', null, InputArgument::OPTIONAL, 'Keep environment file after pushing')
             ->setDescription('Upload the environment file for the given environment');
     }
 
@@ -52,7 +53,7 @@ class EnvPushCommand extends Command
         Helpers::line();
         Helpers::line('You must deploy the project for the new variables to take effect.');
 
-        if (Helpers::confirm('Would you like to delete the environment file from your machine')) {
+        if (! $this->option('keep') && Helpers::confirm('Would you like to delete the environment file from your machine')) {
             @unlink($file);
         }
     }

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -19,7 +19,7 @@ class EnvPushCommand extends Command
             ->setName('env:push')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
             ->addOption('file', null, InputArgument::OPTIONAL, 'File to upload the environment variables from')
-            ->addOption('keep', null, InputArgument::OPTIONAL, 'Keep the environment file after pushing')
+            ->addOption('keep', null, InputArgument::OPTIONAL, 'Do not delete the environment file after pushing')
             ->setDescription('Upload the environment file for the given environment');
     }
 


### PR DESCRIPTION
Currently, when running env:push in a script (to sync in external secrets) it asks a question if the env file locally should be deleted.

This confirm has a default of yes, which personally I don't think it should (it's a destructive action), but nonetheless when `-n` (no interaction) is passed the file is automatically deleted.

This PR adds a `--keep` option which skips the deletion step and question.
Changing the default to not to delete would also work