### PR TITLE
Adds ability to build container image externally

### DIFF
--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -8,7 +8,20 @@ use Laravel\VaporCli\Manifest;
 
 class BuildContainerImage
 {
-    use ParticipatesInBuildProcess;
+    use ParticipatesInBuildProcess {
+        __construct as private configure;
+    }
+
+    /**
+     * @var string|null
+     */
+    private $image;
+
+    public function __construct(?string $environment = null, ?string $image = null)
+    {
+        $this->configure($environment);
+        $this->image = $image;
+    }
 
     /**
      * Execute the build process step.
@@ -18,6 +31,13 @@ class BuildContainerImage
     public function __invoke()
     {
         if (! Manifest::usesContainerImage($this->environment)) {
+            return;
+        }
+
+        if ($this->image) {
+            Helpers::step('<options=bold>Pulling Container Image</>');
+            Docker::pull($this->appPath, Manifest::name(), $this->environment, $this->image);
+
             return;
         }
 

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -42,6 +42,7 @@ class BuildCommand extends Command
             ->setName('build')
             ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
             ->addOption('asset-url', null, InputOption::VALUE_OPTIONAL, 'The asset base URL')
+            ->addOption('prebuilt-image', null, InputOption::VALUE_REQUIRED, 'The image to use instead of building')
             ->setDescription('Build the project archive');
     }
 
@@ -83,7 +84,7 @@ class BuildCommand extends Command
             new ExtractVendorToSeparateDirectory($this->argument('environment')),
             new CompressApplication($this->argument('environment')),
             new CompressVendor($this->argument('environment')),
-            new BuildContainerImage($this->argument('environment')),
+            new BuildContainerImage($this->argument('environment'), $this->option('prebuilt-image')),
         ])->each->__invoke();
 
         $time = (new DateTime())->diff($startedAt)->format('%im%Ss');

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -29,6 +29,29 @@ class Docker
     }
 
     /**
+     * @param  string  $path
+     * @param  string  $project
+     * @param  string  $environment
+     * @param  string  $image
+     * @return void
+     */
+    public static function pull(string $path, string $project, string $environment, string $image): void
+    {
+        Process::fromShellCommandline(
+            sprintf('docker pull %s', escapeshellarg($image)),
+            $path
+        )->setTimeout(null)->mustRun(function ($type, $line) {
+            Helpers::write($line);
+        });
+        Process::fromShellCommandline(
+            sprintf('docker tag %s %s', escapeshellarg($image), Str::slug($project).':'.$environment),
+            $path
+        )->setTimeout(null)->mustRun(function ($type, $line) {
+            Helpers::write($line);
+        });
+    }
+
+    /**
      * Publish a docker image.
      *
      * @param  string  $path


### PR DESCRIPTION
This PR invets two features:

1. Building of the container image now can be made externally with any able builder: docker, kaniko etc.;
2. Do not delete build dir to be abble use it for caching (in CI for example).