### PR TITLE
Adds `open` command

### DIFF
--- a/src/Commands/OpenCommand.php
+++ b/src/Commands/OpenCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
+use Symfony\Component\Console\Input\InputArgument;
+
+class OpenCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('open')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->setDescription('Open an environment in your default browser');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Helpers::ensure_api_token_is_available();
+
+        $environment = $this->vapor->environmentNamed(
+            Manifest::id(),
+            $this->argument('environment')
+        );
+
+        if (empty($environment)) {
+            Helpers::abort(sprintf(
+                'Environment [%s] not found.',
+                $this->argument('environment')
+            ));
+        }
+
+        $domain = ! empty($environment['latest_deployment']['root_domains'])
+            ? $environment['latest_deployment']['root_domains'][0]
+            : $environment['vanity_domain'];
+
+        if (empty($domain)) {
+            Helpers::abort(sprintf(
+                'No domain assigned to [%s] environment.',
+                $this->argument('environment')
+            ));
+        }
+
+        passthru(sprintf('open https://%s', $domain));
+    }
+}

--- a/vapor
+++ b/vapor
@@ -165,6 +165,7 @@ $app->add(new Commands\EnvPullCommand);
 $app->add(new Commands\EnvPushCommand);
 $app->add(new Commands\EnvCloneCommand);
 $app->add(new Commands\EnvDeleteCommand);
+$app->add(new Commands\OpenCommand);
 
 // Secrets
 $app->add(new Commands\SecretListCommand);


### PR DESCRIPTION
This pull request adds a new `open` command that is very useful because you often work with multiple environments, and you don't track vanity / domains. With this new command,  you simply go to the project, and type `vapor open staging` to open the staging environment on the browser.