### PR TITLE
feat: allow opening URLs on multiple OSs

### DIFF
--- a/src/Commands/OpenCommand.php
+++ b/src/Commands/OpenCommand.php
@@ -53,6 +53,14 @@ class OpenCommand extends Command
             ));
         }
 
-        passthru(sprintf('open https://%s', $domain));
+        $openerCommand = 'open';
+
+        if (PHP_OS_FAMILY === 'Windows') {
+            $openerCommand = 'start';
+        } elseif (PHP_OS_FAMILY === 'Linux') {
+            $openerCommand = 'xdg-open';
+        }
+
+        passthru(sprintf('%s https://%s', $openerCommand, $domain));
     }
 }


### PR DESCRIPTION
I'm sure there's probably a neater way of formatting this, however this allows opening on Linux with `xdg-open` and on Windows with `start`, both of which don't support the `open` command.