### PR TITLE
[1.x] Allow to specify database storage of upgraded database

### DIFF
--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -517,13 +517,15 @@ class ConsoleVaporClient
      *
      * @param  string  $databaseId
      * @param  string  $name
+     * @param  int  $storage
      * @param  string  $type
      * @return array
      */
-    public function upgradeDatabase($databaseId, $name, $type)
+    public function upgradeDatabase($databaseId, $name, $storage, $type)
     {
         return $this->requestWithErrorHandling('post', '/api/databases/'.$databaseId.'/upgrades', [
             'name' => $name,
+            'storage' => $storage,
             'type' => $type,
         ]);
     }


### PR DESCRIPTION
This pull request allows to optionally specify the database storage of the upgraded database.

<img width="1328" alt="Screenshot 2021-10-05 at 11 32 36" src="https://user-images.githubusercontent.com/5457236/136007015-f8b72cb6-288e-442d-982b-c1387f82bf49.png">
