### PR TITLE
[Request]: Set Vite asset URL env var during build

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -72,5 +72,10 @@ class SetBuildEnvironment
             $envPath,
             'ASSET_URL='.$this->assetUrl.PHP_EOL
         );
+        
+        $this->files->append(
+            $envPath,
+            'VITE_ASSET_URL='.$this->assetUrl.PHP_EOL
+        );
     }
 }


### PR DESCRIPTION
I am currently using Vitejs to build my assets for applications running on vapor.

Due to Vite not wanting to expose sensitive `.env` vars only vars prefixed with `VITE_` will be loaded.
Since this `ASSET_URL` variable is set during build time, I have not found a clean/easy way to access this during the build process for my frontend scripts, and as such I've been adding this code to my local `vapor-cli` package to allow me to get the paths working with cloudfront and vapor.

If this PR is accepted, it would allow me to do the following.
![image](https://user-images.githubusercontent.com/228899/137011670-0ccf99c4-8b64-43f7-8156-b4d20e485830.png)


This would make loading assets from the right (dynamic) cloudfront URL easier and solve a headache for me and hopfully others that are now using Vitejs.


Thanks for your time,


Yaz
