### PR TITLE
[1.x] Append `MIX_VAPOR_ASSET_URL` as environment variable

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -72,5 +72,10 @@ class SetBuildEnvironment
             $envPath,
             'ASSET_URL='.$this->assetUrl.PHP_EOL
         );
+
+        $this->files->append(
+            $envPath,
+            'MIX_VAPOR_ASSET_URL='.$this->assetUrl.PHP_EOL
+        );
     }
 }


### PR DESCRIPTION
This pull request adds `MIX_VAPOR_ASSET_URL` as environment variable to the build step, that is used by the `asset` helper. For more information, check https://github.com/laravel/vapor-docs/pull/102.