### PR TITLE
Uses PHP 8.1 by default

### DIFF
--- a/src/Commands/EnvCommand.php
+++ b/src/Commands/EnvCommand.php
@@ -45,7 +45,7 @@ class EnvCommand extends Command
         Manifest::addEnvironment($environment, [
             'memory'     => 1024,
             'cli-memory' => 512,
-            'runtime'    => $this->option('docker') ? 'docker' : 'php-8.0:al2',
+            'runtime'    => $this->option('docker') ? 'docker' : 'php-8.1:al2',
             'build'      => [
                 'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                 'php artisan event:cache',

--- a/src/Commands/LocalCommand.php
+++ b/src/Commands/LocalCommand.php
@@ -19,6 +19,7 @@ class LocalCommand extends Command
         '7.3' => 'laravelphp/vapor:php73',
         '7.4' => 'laravelphp/vapor:php74',
         '8.0' => 'laravelphp/vapor:php80',
+        '8.1' => 'laravelphp/vapor:php81',
     ];
 
     /**

--- a/src/Dockerfile.php
+++ b/src/Dockerfile.php
@@ -13,7 +13,7 @@ class Dockerfile
     public static function fresh($environment)
     {
         $content = <<<'Dockerfile'
-FROM laravelphp/vapor:php80
+FROM laravelphp/vapor:php81
 
 COPY . /var/task
 Dockerfile;

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -187,7 +187,7 @@ class Manifest
                 'production' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-8.0:al2',
+                    'runtime'    => 'php-8.1:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                         'php artisan event:cache',
@@ -197,7 +197,7 @@ class Manifest
                 'staging' => array_filter([
                     'memory'     => 1024,
                     'cli-memory' => 512,
-                    'runtime'    => 'php-8.0:al2',
+                    'runtime'    => 'php-8.1:al2',
                     'build'      => [
                         'COMPOSER_MIRROR_PATH_REPOS=1 composer install',
                         'php artisan event:cache',


### PR DESCRIPTION
This pull request uses PHP 8.1 by default in Vapor CLI.