### PR TITLE
[1.x] Fixes missing project dependencies

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -45,6 +45,7 @@ class DeployCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
+        $this->ensureProjectDependenciesAreInstalled();
         $this->ensureManifestIsValid();
 
         // First we will build the project and create a new deployment artifact for the
@@ -88,6 +89,20 @@ class DeployCommand extends Command
             $this->getCliVersion(),
             $this->getCoreVersion()
         );
+    }
+
+    /**
+     * Ensure the project's dependencies are installed.
+     *
+     * @return void
+     */
+    protected function ensureProjectDependenciesAreInstalled()
+    {
+        if (! file_exists(Path::current().'/vendor/composer/installed.json')) {
+            Helpers::abort(
+                'Unable to find your project\'s dependencies. Please run the composer "install" command first.'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
This pull request fixes an issue that may occur on CI environments were people tend to run "vapor deploy" without installing the project's dependencies first.

And, currently, we need multiple files within the vendor directory for computing md5s, etc.