### PR TITLE
Support Docker --build-arg option

### DIFF
--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -9,9 +9,14 @@ use Laravel\VaporCli\Manifest;
 class BuildContainerImage
 {
     use ParticipatesInBuildProcess {
-        ParticipatesInBuildProcess::__construct as buildProcessConstruct;
+        ParticipatesInBuildProcess::__construct as baseConstructor;
     }
 
+    /**
+     * The Docker build arguments.
+     *
+     * @var array
+     */
     protected $buildArgs;
 
     /**
@@ -23,7 +28,8 @@ class BuildContainerImage
      */
     public function __construct($environment = null, $buildArgs = [])
     {
-        $this->buildProcessConstruct($environment);
+        $this->baseConstructor($environment);
+
         $this->buildArgs = $buildArgs;
     }
 

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -17,8 +17,9 @@ class BuildContainerImage
     /**
      * Create a new project builder.
      *
-     * @param string|null $environment
-     * @param array $buildArgs
+     * @param  string|null  $environment
+     * @param  array  $buildArgs
+     * @return void
      */
     public function __construct($environment = null, $buildArgs = [])
     {

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -8,7 +8,23 @@ use Laravel\VaporCli\Manifest;
 
 class BuildContainerImage
 {
-    use ParticipatesInBuildProcess;
+    use ParticipatesInBuildProcess {
+        ParticipatesInBuildProcess::__construct as buildProcessConstruct;
+    }
+
+    protected $buildArgs;
+
+    /**
+     * Create a new project builder.
+     *
+     * @param string|null $environment
+     * @param array $buildArgs
+     */
+    public function __construct($environment = null, $buildArgs = [])
+    {
+        $this->buildProcessConstruct($environment);
+        $this->buildArgs = $buildArgs;
+    }
 
     /**
      * Execute the build process step.
@@ -23,7 +39,7 @@ class BuildContainerImage
 
         Helpers::step('<options=bold>Building Container Image</>');
 
-        Docker::build($this->appPath, Manifest::name(), $this->environment);
+        Docker::build($this->appPath, Manifest::name(), $this->environment, $this->buildArgs);
     }
 
     /**

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -43,6 +43,7 @@ class BuildCommand extends Command
             ->setName('build')
             ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
             ->addOption('asset-url', null, InputOption::VALUE_OPTIONAL, 'The asset base URL')
+            ->addOption('build-arg', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build argument')
             ->setDescription('Build the project archive');
     }
 
@@ -85,7 +86,7 @@ class BuildCommand extends Command
             new ExtractVendorToSeparateDirectory($this->argument('environment')),
             new CompressApplication($this->argument('environment')),
             new CompressVendor($this->argument('environment')),
-            new BuildContainerImage($this->argument('environment')),
+            new BuildContainerImage($this->argument('environment'), $this->option('build-arg')),
         ])->each->__invoke();
 
         $time = (new DateTime())->diff($startedAt)->format('%im%Ss');

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -33,6 +33,7 @@ class DeployCommand extends Command
             ->addOption('message', null, InputOption::VALUE_OPTIONAL, 'The message for the commit that is being deployed')
             ->addOption('without-waiting', null, InputOption::VALUE_NONE, 'Deploy without waiting for progress')
             ->addOption('fresh-assets', null, InputOption::VALUE_NONE, 'Upload a fresh copy of all assets')
+            ->addOption('build-arg', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build argument')
             ->setDescription('Deploy an environment');
     }
 
@@ -119,6 +120,7 @@ class DeployCommand extends Command
             'environment' => $this->argument('environment'),
             '--asset-url' => $this->assetDomain($project).'/'.$uuid,
             '--manifest' => Path::manifest(),
+            '--build-arg' => $this->option('build-arg'),
         ]);
 
         return $this->uploadArtifact(

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -44,7 +44,7 @@ class Docker
                 ->merge(Collection::make($cliBuildArgs)
                     ->mapWithKeys(function ($value) {
                         [$key, $value] = explode('=', $value, 2);
-                        
+
                         return [$key => $value];
                     })
                 )->map(function ($value, $key) {

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -19,7 +19,7 @@ class Docker
     public static function build($path, $project, $environment, $cliBuildArgs)
     {
         Process::fromShellCommandline(
-            static::buildCommand($project, $environment, $cliBuildArgs, Manifest::buildArgs($environment)),
+            static::buildCommand($project, $environment, $cliBuildArgs, Manifest::dockerBuildArgs($environment)),
             $path
         )->setTimeout(null)->mustRun(function ($type, $line) {
             Helpers::write($line);
@@ -27,7 +27,7 @@ class Docker
     }
 
     /**
-     * Build docker build command string.
+     * Create the Docker build command string.
      *
      * @param  string  $project
      * @param  string  $environment

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -44,6 +44,7 @@ class Docker
                 ->merge(Collection::make($cliBuildArgs)
                     ->mapWithKeys(function ($value) {
                         [$key, $value] = explode('=', $value, 2);
+                        
                         return [$key => $value];
                     })
                 )->map(function ($value, $key) {

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -27,12 +27,12 @@ class Docker
     }
 
     /**
-     * Build docker build command string
+     * Build docker build command string.
      *
-     * @param string $project
-     * @param string $environment
-     * @param array $cliBuildArgs
-     * @param array $manifestBuildArgs
+     * @param  string  $project
+     * @param  string  $environment
+     * @param  array  $cliBuildArgs
+     * @param  array  $manifestBuildArgs
      * @return string
      */
     public static function buildCommand($project, $environment, $cliBuildArgs, $manifestBuildArgs)

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -61,9 +61,9 @@ class Manifest
      * @param  string  $environment
      * @return array
      */
-    public static function buildArgs($environment)
+    public static function dockerBuildArgs($environment)
     {
-        return static::current()['environments'][$environment]['build-arg'] ?? [];
+        return static::current()['environments'][$environment]['docker-build-args'] ?? [];
     }
 
     /**

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -56,6 +56,17 @@ class Manifest
     }
 
     /**
+     * Get the Docker build arguments
+     *
+     * @param string $environment
+     * @return array
+     */
+    public static function buildArgs($environment)
+    {
+        return static::current()['environments'][$environment]['build-arg'] ?? [];
+    }
+
+    /**
      * Determine if the environment uses a database proxy.
      *
      * @param  string  $environment

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -56,9 +56,9 @@ class Manifest
     }
 
     /**
-     * Get the Docker build arguments
+     * Get the Docker build arguments.
      *
-     * @param string $environment
+     * @param  string  $environment
      * @return array
      */
     public static function buildArgs($environment)

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Laravel\VaporCli\Tests;
+
+use Laravel\VaporCli\Docker;
+use PHPUnit\Framework\TestCase;
+
+class DockerTest extends TestCase
+{
+    public function test_build_command_no_build_args()
+    {
+        $command = Docker::buildCommand('my-project', 'production', [], []);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production .';
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_build_command_cli_build_args()
+    {
+        $cliBuildArgs = ['FOO=BAR', 'FIZZ=BUZZ'];
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, []);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_build_command_manifest_build_args()
+    {
+        $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
+        $command = Docker::buildCommand('my-project', 'production', [], $manifestBuildArgs);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_build_command_cli_and_manifest_build_args()
+    {
+        $cliBuildArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
+        $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, $manifestBuildArgs);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BAZZ' --build-arg='BAR=FOO' .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+}


### PR DESCRIPTION
Our Vapor project that uses the Docker runtime depends on certain PHP extensions that have .ini configuration values that need to be set at image build time.

The value of these configurations vary by environment and also contains some sensitive values such as API keys.

To prevent hardcoding these values in the Dockerfile, we've defined `sed` commands in the `build` vapor.yml key of each environment that replace placeholder strings in our Dockerfiles prior to the image being built. 

It's a kind of hacky approach. it'd be more ideal if we could make use of the Dockerfile [`ARG`](https://docs.docker.com/engine/reference/builder/#arg) keyword and the [`docker build --build-arg`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) option.

This PR allows for defining a `build-arg` key for each environment in vapor.yml. 

ex:

```yaml
id: 1
name: my-project
environments:
  staging:
    memory: 1024
    cli-memory: 512
    runtime: docker
    build-arg:
      FOO: BAR
      FIZZ: BUZZ
    build:
      - 'COMPOSER_MIRROR_PATH_REPOS=1 composer install'
      - 'php artisan event:cache'
      - 'npm ci && npm run dev && rm -rf node_modules'
```

Build arguments can also be provided to the deploy and build commands. This can be leveraged to inject secret values from the CI pipeline. 

ex:

`vapor deploy staging --build-arg FOO=BAR --build-arg FIZZ=BUZZ`

`vapor build staging --build-arg FOO=BAR --build-arg FIZZ=BUZZ`

The merged build arguments from vapor.yml and the deploy/build command options will be passed to the `docker build` command.

If a build argument is present in both vapor.yml and as a CLI option, the CLI option value will take priority. 