### PR TITLE
Fixes the return type of the `createNetwork` method.

### DIFF
--- a/src/Commands/NetworkCommand.php
+++ b/src/Commands/NetworkCommand.php
@@ -29,7 +29,7 @@ class NetworkCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
-        $network = $this->vapor->createNetwork(
+        $this->vapor->createNetwork(
             $this->determineProvider('Which cloud provider should the network belong to?'),
             $this->argument('network'),
             $this->determineRegion('Which region should the network be placed in?'),

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -318,7 +318,7 @@ class ConsoleVaporClient
      * @param  string  $name
      * @param  string  $region
      * @param  bool  $withInternetAccess
-     * @return array
+     * @return void
      */
     public function createNetwork($providerId, $name, $region, $withInternetAccess)
     {


### PR DESCRIPTION
This pull request fixes the return type of the `createNetwork` method.