### PR TITLE
Added fix to skip database file removal if dir not found

### DIFF
--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -55,6 +55,10 @@ class RemoveIgnoredFiles
             }
         }
 
+        if (!$this->files->exists(Path::app().'/database')) {
+            return;
+        }
+
         $files = (new Finder())
             ->in(Path::app().'/database')
             ->depth('== 0')

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -55,7 +55,7 @@ class RemoveIgnoredFiles
             }
         }
 
-        if (!$this->files->exists(Path::app().'/database')) {
+        if (! $this->files->exists(Path::app().'/database')) {
             return;
         }
 


### PR DESCRIPTION
During the `Removing Ignored Files` deployment stage, `RemoveIgnoredFiles` scans the `${build}/app/databases` path for `*.sqlite` files to remove. This causes a failure if the `${build}/app/databases` dir does not exist. This PR simply adds a check for the dir and early exits if it is not found.