### PR TITLE
Add option to force environment and database deletion

### DIFF
--- a/src/Commands/DatabaseDeleteCommand.php
+++ b/src/Commands/DatabaseDeleteCommand.php
@@ -4,6 +4,7 @@ namespace Laravel\VaporCli\Commands;
 
 use Laravel\VaporCli\Helpers;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class DatabaseDeleteCommand extends Command
 {
@@ -17,6 +18,7 @@ class DatabaseDeleteCommand extends Command
         $this
             ->setName('database:delete')
             ->addArgument('database', InputArgument::REQUIRED, 'The database name / ID')
+            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion, use wisely')
             ->setDescription('Delete a database');
     }
 
@@ -27,7 +29,9 @@ class DatabaseDeleteCommand extends Command
      */
     public function handle()
     {
-        if (! Helpers::confirm('Are you sure you want to delete this database', false)) {
+        $forceDeletion = $this->option('force', false);
+
+        if (! $forceDeletion && ! Helpers::confirm('Are you sure you want to delete this database', false)) {
             Helpers::abort('Action cancelled.');
         }
 

--- a/src/Commands/DatabaseDeleteCommand.php
+++ b/src/Commands/DatabaseDeleteCommand.php
@@ -18,7 +18,7 @@ class DatabaseDeleteCommand extends Command
         $this
             ->setName('database:delete')
             ->addArgument('database', InputArgument::REQUIRED, 'The database name / ID')
-            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion, use wisely')
+            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion of the database without confirmation')
             ->setDescription('Delete a database');
     }
 

--- a/src/Commands/EnvDeleteCommand.php
+++ b/src/Commands/EnvDeleteCommand.php
@@ -32,6 +32,7 @@ class EnvDeleteCommand extends Command
     public function handle()
     {
         $environment = $this->argument('environment');
+
         $forceDeletion = $this->option('force', false);
 
         if (! $forceDeletion && ! Helpers::confirm("Are you sure you want to delete the [{$environment}] environment", false)) {

--- a/src/Commands/EnvDeleteCommand.php
+++ b/src/Commands/EnvDeleteCommand.php
@@ -20,7 +20,7 @@ class EnvDeleteCommand extends Command
         $this
             ->setName('env:delete')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion, use wisely')
+            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion of the environment without confirmation')
             ->setDescription('Delete an environment');
     }
 

--- a/src/Commands/EnvDeleteCommand.php
+++ b/src/Commands/EnvDeleteCommand.php
@@ -6,6 +6,7 @@ use Laravel\VaporCli\Dockerfile;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Manifest;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class EnvDeleteCommand extends Command
 {
@@ -19,6 +20,7 @@ class EnvDeleteCommand extends Command
         $this
             ->setName('env:delete')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion, use wisely')
             ->setDescription('Delete an environment');
     }
 
@@ -30,8 +32,9 @@ class EnvDeleteCommand extends Command
     public function handle()
     {
         $environment = $this->argument('environment');
+        $forceDeletion = $this->option('force', false);
 
-        if (! Helpers::confirm("Are you sure you want to delete the [{$environment}] environment", false)) {
+        if (! $forceDeletion && ! Helpers::confirm("Are you sure you want to delete the [{$environment}] environment", false)) {
             Helpers::abort('Action cancelled.');
         }
 


### PR DESCRIPTION
With the idea of integrating Vapor even further in automations, I propose to add `--force` option to both `database:delete` as well as `env:delete`

At the moment these cannot be automatically deleted because they have a `Helper::confirm()` gate keeping the action.

I understand the risks of such option but I believe it's meant to be used wisely, as the description of the command details.

### CHANGELOG

1. Added `--force` to `database:delete` command, allowing to over-pass confirmation. Example: `php vendor/bin/vapor database:delete database-name --force`
2. Added `--force` to `env:delete` command, allowing to over-pass confirmation. Example: `php vendor/bin/vapor env:delete environment-name --force`