### PR TITLE
Added feature to not overwrite existing handlers if found in core application

### DIFF
--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -64,7 +64,7 @@ class InjectHandlers
     }
 
     /**
-     * Copy a file to a new location if that file does not exist
+     * Copy a file to a new location if that file does not exist.
      *
      * @param  string  $path
      * @param  string  $target

--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -65,16 +65,14 @@ class InjectHandlers
     /**
      * Copy a file to a new location if that file does not exist.
      *
-     * @param  string  $path
-     * @param  string  $target
-     * @return bool
+     * @param  string  $from
+     * @param  string  $to
+     * @return void
      */
-    protected function copyMissing($path, $target)
+    protected function copyMissing($from, $to)
     {
-        if ($this->files->exists($target)) {
-            return true;
+        if (! $this->files->exists($to)) {
+            $this->files->copy($from, $to);
         }
-
-        return $this->files->copy($path, $target);
     }
 }

--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -35,8 +35,7 @@ class InjectHandlers
         $this->copyMissing($stubPath.'/httpRuntime.php', $this->appPath.'/httpRuntime.php');
         $this->copyMissing($stubPath.'/httpHandler.php', $this->appPath.'/httpHandler.php');
 
-        if (Manifest::shouldSeparateVendor($this->environment) &&
-            ! $this->files->exists($this->appPath.'/httpHandler.php')) {
+        if (Manifest::shouldSeparateVendor($this->environment)) {
             file_put_contents(
                 $this->appPath.'/httpHandler.php',
                 $this->configureHttpHandler($this->appPath.'/httpHandler.php')

--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -30,12 +30,13 @@ class InjectHandlers
             $this->files->copy($stubPath.'/runtime.php', $this->appPath.'/runtime.php');
         }
 
-        $this->files->copy($stubPath.'/cliRuntime.php', $this->appPath.'/cliRuntime.php');
-        $this->files->copy($stubPath.'/fpmRuntime.php', $this->appPath.'/fpmRuntime.php');
-        $this->files->copy($stubPath.'/httpRuntime.php', $this->appPath.'/httpRuntime.php');
-        $this->files->copy($stubPath.'/httpHandler.php', $this->appPath.'/httpHandler.php');
+        $this->copyMissing($stubPath.'/cliRuntime.php', $this->appPath.'/cliRuntime.php');
+        $this->copyMissing($stubPath.'/fpmRuntime.php', $this->appPath.'/fpmRuntime.php');
+        $this->copyMissing($stubPath.'/httpRuntime.php', $this->appPath.'/httpRuntime.php');
+        $this->copyMissing($stubPath.'/httpHandler.php', $this->appPath.'/httpHandler.php');
 
-        if (Manifest::shouldSeparateVendor($this->environment)) {
+        if (Manifest::shouldSeparateVendor($this->environment) &&
+            ! $this->files->exists($this->appPath.'/httpHandler.php')) {
             file_put_contents(
                 $this->appPath.'/httpHandler.php',
                 $this->configureHttpHandler($this->appPath.'/httpHandler.php')
@@ -60,5 +61,21 @@ class InjectHandlers
             "require '/tmp/vendor/autoload.php';",
             file_get_contents($file)
         );
+    }
+
+    /**
+     * Copy a file to a new location if that file does not exist
+     *
+     * @param  string  $path
+     * @param  string  $target
+     * @return bool
+     */
+    protected function copyMissing($path, $target)
+    {
+        if ($this->files->exists($target)) {
+            return true;
+        }
+
+        return $this->files->copy($path, $target);
     }
 }


### PR DESCRIPTION
This PR introduces a simple change that allows for handlers to be embedded within the application and prevents `vapor-cli` from replacing them upon deployment.

## Usage

In WinterCMS (a Laravel powered CMS) we utilise our own [`autoload.php`](https://github.com/wintercms/winter/blob/develop/bootstrap/autoload.php) which allows us to load our custom helpers before composer loads those provided by Laravel.

The core issue (being able to autoload files in a specific order) was recently closed by composer: 
 https://github.com/composer/composer/issues/6768

Unfortunately when deploying with Vapor, the `httpHandler.php` is injected which calls:
```php
require __DIR__.'/vendor/autoload.php';
```

This means that our application helpers are replaced by the core Laravel ones.


