### PR TITLE
WARNING! Using --password via the CLI is insecure. Use --password-stdin

### DIFF
--- a/src/Docker.php
+++ b/src/Docker.php
@@ -76,7 +76,7 @@ class Docker
         )->setTimeout(null)->mustRun();
 
         Process::fromShellCommandline(
-            sprintf('docker login --username AWS --password %s %s',
+            sprintf('docker login --username AWS --password-stdin %s %s',
                 str_replace('AWS:', '', base64_decode($token)),
                 explode('/', $repoUri)[0]
             ),


### PR DESCRIPTION
According to Docker's documentation:
Provide a password using STDIN
To run the docker login command non-interactively, you can set the --password-stdin flag to provide a password through STDIN. Using STDIN prevents the password from ending up in the shell’s history, or log-files.