### PR TITLE
Deprecates PostgreSQL 10.7

### DIFF
--- a/src/Commands/DatabaseCommand.php
+++ b/src/Commands/DatabaseCommand.php
@@ -113,7 +113,6 @@ class DatabaseCommand extends Command
             'aurora-serverless'       => 'Serverless MySQL Aurora Cluster',
             'rds-pgsql-13.4'          => 'Fixed Size PostgreSQL Instance 13.4',
             'rds-pgsql-11.10'         => 'Fixed Size PostgreSQL Instance 11.10',
-            'rds-pgsql'               => 'Fixed Size PostgreSQL Instance 10.7',
             'aurora-serverless-pgsql' => 'Serverless PostgreSQL Aurora Cluster',
         ]), function ($type) use ($public) {
             if ($type == 'aurora-serverless' && $public) {
@@ -140,7 +139,6 @@ class DatabaseCommand extends Command
 
         if ($type == 'rds'
             || $type == 'rds-mysql-5.7'
-            || $type == 'rds-pgsql'
             || $type == 'rds-pgsql-11.10'
             || $type == 'rds-pgsql-13.4') {
             return $this->determineRdsInstanceClass();


### PR DESCRIPTION
This pull request deprecates PostgreSQL 10.7, as its end-of-life is this year.