### PR TITLE
Fix syntax error with PHP 7.2

### DIFF
--- a/src/Commands/DatabaseUpgradeCommand.php
+++ b/src/Commands/DatabaseUpgradeCommand.php
@@ -106,7 +106,7 @@ class DatabaseUpgradeCommand extends Command
             return $this->menu('Which type of database would you like to create?', collect($this->databaseTypes)
                 ->filter(function ($label, $type) use ($possibleUpgrades) {
                     return in_array($type, $possibleUpgrades);
-                })->all(),
+                })->all()
             );
         }
     }


### PR DESCRIPTION
Since `composer.json` specifies support for PHP 7.2 no syntax features from later PHP versions should be used.

PHP added support for trailing commas in function calls in version 7.3 (https://wiki.php.net/rfc/trailing-comma-function-calls). Therefore, they should not be used in the code.