### PR TITLE
Fixes `env:describe` without any previous deployments

### DIFF
--- a/src/Commands/EnvDescribeCommand.php
+++ b/src/Commands/EnvDescribeCommand.php
@@ -42,7 +42,7 @@ class EnvDescribeCommand extends Command
             $this->argument('environment')
         );
 
-        $domains =  [];
+        $domains = [];
 
         if ($environment['latest_deployment']) {
             $domains = $environment['latest_deployment']['root_domains'] ?: [];

--- a/src/Commands/EnvDescribeCommand.php
+++ b/src/Commands/EnvDescribeCommand.php
@@ -42,7 +42,11 @@ class EnvDescribeCommand extends Command
             $this->argument('environment')
         );
 
-        $domains = $environment['latest_deployment']['root_domains'] ?: [];
+        $domains =  [];
+
+        if ($environment['latest_deployment']) {
+            $domains = $environment['latest_deployment']['root_domains'] ?: [];
+        }
 
         $domain = count($domains) ? $domains[0] : null;
 
@@ -53,7 +57,7 @@ class EnvDescribeCommand extends Command
             'name'                     => $environment['name'],
             'vanity_domain'            => $environment['vanity_domain'],
             'latest_deployment_id'     => $environment['latest_deployment_id'],
-            'latest_deployment_status' => $environment['latest_deployment']['status'],
+            'latest_deployment_status' => $environment['latest_deployment'] ? $environment['latest_deployment']['status'] : null,
             'latest_deployment_url'    => 'https://vapor.laravel.com/app/projects/'.$environment['project_id'].'/environments/'.$environment['name'].'/deployments/'.$environment['latest_deployment_id'],
             'deployment_status'        => $environment['deployment_status'],
             'domains'                  => $domains,


### PR DESCRIPTION
Fixes `env:describe` when no previous deployments were made yet.

<img width="454" alt="Screenshot 2022-03-25 at 16 07 03" src="https://user-images.githubusercontent.com/5457236/160158162-090ab396-87a8-4f7d-9b06-303c99fd832b.png">
tay
