### PR TITLE
Specify Environment Dockerfile Path In Manifest

### DIFF
--- a/src/Docker.php
+++ b/src/Docker.php
@@ -38,8 +38,8 @@ class Docker
      */
     public static function buildCommand($project, $environment, $cliBuildArgs, $manifestBuildArgs)
     {
-        return sprintf('docker build --pull --file=%s.Dockerfile --tag=%s %s.',
-            $environment,
+        return sprintf('docker build --pull --file=%s --tag=%s %s.',
+            Manifest::dockerfile($environment),
             Str::slug($project).':'.$environment,
             Collection::make($manifestBuildArgs)
                 ->merge(Collection::make($cliBuildArgs)

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -67,6 +67,17 @@ class Manifest
     }
 
     /**
+     * Get the Dockerfile.
+     *
+     * @param  string  $environment
+     * @return string
+     */
+    public static function dockerfile($environment)
+    {
+        return static::current()['environments'][$environment]['dockerfile'] ?? "{$environment}.Dockerfile";
+    }
+
+    /**
      * Determine if the environment uses a database proxy.
      *
      * @param  string  $environment

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -56,6 +56,17 @@ class Manifest
     }
 
     /**
+     * Get the Dockerfile for the given environment.
+     *
+     * @param  string  $environment
+     * @return string
+     */
+    public static function dockerfile($environment)
+    {
+        return static::current()['environments'][$environment]['dockerfile'] ?? "{$environment}.Dockerfile";
+    }
+
+    /**
      * Get the Docker build arguments.
      *
      * @param  string  $environment
@@ -64,17 +75,6 @@ class Manifest
     public static function dockerBuildArgs($environment)
     {
         return static::current()['environments'][$environment]['docker-build-args'] ?? [];
-    }
-
-    /**
-     * Get the Dockerfile.
-     *
-     * @param  string  $environment
-     * @return string
-     */
-    public static function dockerfile($environment)
-    {
-        return static::current()['environments'][$environment]['dockerfile'] ?? "{$environment}.Dockerfile";
     }
 
     /**

--- a/src/Path.php
+++ b/src/Path.php
@@ -112,6 +112,6 @@ class Path
      */
     public static function dockerfile($environment)
     {
-        return getcwd().'/'.$environment.'.Dockerfile';
+        return getcwd().'/'.Manifest::dockerfile($environment);
     }
 }

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -2,11 +2,26 @@
 
 namespace Laravel\VaporCli\Tests;
 
+use Illuminate\Container\Container;
 use Laravel\VaporCli\Docker;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
 
 class DockerTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+        touch($testManifest = getcwd().'/test.vapor.yml');
+        Container::getInstance()->offsetSet('manifest', $testManifest);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink(Container::getInstance()->offsetGet('manifest'));
+        parent::tearDown();
+    }
+
     public function test_build_command_no_build_args()
     {
         $command = Docker::buildCommand('my-project', 'production', [], []);
@@ -39,6 +54,23 @@ class DockerTest extends TestCase
         $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, $manifestBuildArgs);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--build-arg='FOO=BAR' --build-arg='FIZZ=BAZZ' --build-arg='BAR=FOO' .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_dockerfile_from_manifest()
+    {
+        file_put_contents(Container::getInstance()->offsetGet('manifest'), Yaml::dump([
+            'id'           => 1,
+            'name'         => 'Test',
+            'environments' => [
+                'production' => [
+                    'runtime'    => 'docker',
+                    'dockerfile' => 'docker/shared.Dockerfile',
+                ],
+            ],
+        ]));
+        $command = Docker::buildCommand('my-project', 'production', [], []);
+        $expectedCommand = 'docker build --pull --file=docker/shared.Dockerfile --tag=my-project:production .';
         $this->assertEquals($expectedCommand, $command);
     }
 }


### PR DESCRIPTION
I've found the current convention for Dockerfile paths to be a papercut annoyance for Docker runtime Vapor projects with many environments. 

As is, Dockerfiles must be stored in the project root, and chances are they will not be grouped together in an alphabetical directory listing due to the environment name serving as the filename prefix. 

In addition, each environment must have its own Dockerfile. Often the Dockerfile contents for multiple environments end up being identical, or, things could be structured such that multiple environments could share a Dockerfile by taking advantage of unique Docker build argument values per environment.

This PR allows for specifying a custom Dockerfile path for each environment via a new optional `dockerfile` field in the Vapor manifest file.

This will allow developers to incorporate their preferred filename convention for Dockerfiles, store Dockerfiles in subdirectories, and share Dockerfiles between environments. 

If the `dockerfile` field is not specified for an environment, the current `{environment}.Dockerfile` filename convention is preserved. 