### PR TITLE
Change cache-control max-age default value for improve long live assets caching

### DIFF
--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -99,7 +99,7 @@ class AwsStorageProvider
                     $request['url'],
                     array_merge(
                         $request['headers'],
-                        ['Cache-Control' => 'public, max-age=2628000']
+                        ['Cache-Control' => 'public, max-age=31536000']
                     )
                 );
             }

--- a/src/ServeAssets.php
+++ b/src/ServeAssets.php
@@ -51,7 +51,7 @@ class ServeAssets
 
             $storage->store(
                 $request['url'],
-                array_merge($request['headers'], ['Cache-Control' => 'public, max-age=2628000']),
+                array_merge($request['headers'], ['Cache-Control' => 'public, max-age=31536000']),
                 $assetPath.'/'.$request['path']
             );
         }


### PR DESCRIPTION
Hi 👋🏽 

This pull request is a reflection of the previous one: [#181](https://github.com/laravel/vapor-cli/pull/181).

Assets served by Vapor will always have a unique URL for them, we should be able to set the maximum expiration time (1 year) which will tell the CDN (CloudFront) and the user browser to keep the asset for a long, long time, saving bandwidth and energy. 😄 

This is based on recommendations from https://web.dev/http-cache/#versioned-urls 🚀 

Thanks in advance 😄 

