### PR TITLE
Removes 500 public assets limitation and makes files uploads concurrent

### DIFF
--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -114,7 +114,7 @@ class AwsStorageProvider
                             $request['headers'],
                             ['Cache-Control' => 'public, max-age=31536000']
                         ),
-                        $request['stream'],
+                        $request['stream']
                     );
                 }
             };

--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -143,7 +143,7 @@ class AwsStorageProvider
      */
     public function executeCopyRequests($requests, $callback)
     {
-        $generator = function () use ($requests) {
+        $generator = function () use ($requests, $callback) {
             foreach ($requests as $request) {
                 $callback($request);
 

--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -5,8 +5,9 @@ namespace Laravel\VaporCli\Aws;
 use GuzzleHttp\Client;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7\Request;
+use Illuminate\Support\LazyCollection;
 use Laravel\VaporCli\ConsoleVaporClient;
-use Laravel\VaporCli\Exceptions\CopyRequestFailedException;
+use Laravel\VaporCli\Exceptions\RequestFailedException;
 use Laravel\VaporCli\Helpers;
 use Symfony\Component\Console\Helper\ProgressBar;
 
@@ -85,15 +86,67 @@ class AwsStorageProvider
     }
 
     /**
+     * Execute the given store requests.
+     *
+     * @param  array  $requests
+     * @param  string  $assetPath
+     * @param  callable  $callback
+     * @return void
+     */
+    public function executeStoreRequests($requests, $assetPath, $callback)
+    {
+        collect($requests)->chunk(10)->each(function ($chunkOfRequests) use ($assetPath, $callback) {
+            $requests = LazyCollection::make($chunkOfRequests)->map(function ($request) use ($assetPath) {
+                $file = $assetPath.'/'.$request['path'];
+                $request['stream'] = fopen($file, 'r+');
+
+                return $request;
+            });
+
+            $generator = function () use ($requests, $callback) {
+                foreach ($requests as $request) {
+                    $callback($request);
+
+                    yield new Request(
+                        'PUT',
+                        $request['url'],
+                        array_merge(
+                            $request['headers'],
+                            ['Cache-Control' => 'public, max-age=31536000']
+                        ),
+                        $request['stream'],
+                    );
+                }
+            };
+
+            (new Pool(new Client(), $generator(), [
+                'concurrency' => 10,
+                'rejected' => function ($reason, $index) {
+                    throw new RequestFailedException($reason->getMessage(), $index);
+                },
+            ]))
+                ->promise()
+                ->wait();
+
+            $requests->each(function ($request) {
+                fclose($request['stream']);
+            });
+        });
+    }
+
+    /**
      * Execute the given copy requests.
      *
      * @param  array  $requests
+     * @param  callable  $callback
      * @return void
      */
-    public function executeCopyRequests($requests)
+    public function executeCopyRequests($requests, $callback)
     {
-        $requests = function () use ($requests) {
+        $generator = function () use ($requests) {
             foreach ($requests as $request) {
+                $callback($request);
+
                 yield new Request(
                     'PUT',
                     $request['url'],
@@ -105,10 +158,10 @@ class AwsStorageProvider
             }
         };
 
-        (new Pool(new Client(), $requests(), [
+        (new Pool(new Client(), $generator(), [
             'concurrency' => 10,
             'rejected' => function ($reason, $index) {
-                throw new CopyRequestFailedException($reason->getMessage(), $index);
+                throw new RequestFailedException($reason->getMessage(), $index);
             },
         ]))
             ->promise()

--- a/src/Exceptions/RequestFailedException.php
+++ b/src/Exceptions/RequestFailedException.php
@@ -4,7 +4,7 @@ namespace Laravel\VaporCli\Exceptions;
 
 use RuntimeException;
 
-class CopyRequestFailedException extends RuntimeException
+class RequestFailedException extends RuntimeException
 {
     /**
      * The file index.

--- a/src/ServeAssets.php
+++ b/src/ServeAssets.php
@@ -29,7 +29,7 @@ class ServeAssets
                     $vapor,
                     $artifact,
                     $chunkOfAssetFiles,
-                    $fresh,
+                    $fresh
                 );
 
                 $this->executeStoreAssetRequests($requests['store'], $assetPath);

--- a/src/ServeAssets.php
+++ b/src/ServeAssets.php
@@ -82,7 +82,7 @@ class ServeAssets
 
         if (! empty($requests)) {
             try {
-                $storage->executeCopyRequests($requests, function () use ($assetPath) {
+                $storage->executeCopyRequests($requests, function ($request) use ($assetPath) {
                     Helpers::step('<fg=magenta>Copying Unchanged Asset:</> '.$request['path'].' ('.Helpers::kilobytes($assetPath.'/'.$request['path']).')');
                 });
             } catch (RequestFailedException $e) {

--- a/src/ServeAssets.php
+++ b/src/ServeAssets.php
@@ -3,7 +3,7 @@
 namespace Laravel\VaporCli;
 
 use Laravel\VaporCli\Aws\AwsStorageProvider;
-use Laravel\VaporCli\Exceptions\CopyRequestFailedException;
+use Laravel\VaporCli\Exceptions\RequestFailedException;
 
 class ServeAssets
 {
@@ -18,21 +18,28 @@ class ServeAssets
     public function __invoke(ConsoleVaporClient $vapor, array $artifact, $fresh)
     {
         $assetPath = Path::build().'/assets';
+        $assetFiles = $this->getAssetFiles($assetPath);
 
-        $requests = $this->getAuthorizedAssetRequests(
-            $vapor,
-            $artifact,
-            $assetFiles = $this->getAssetFiles($assetPath),
-            $fresh
-        );
+        collect($assetFiles)
+            ->chunk(400)
+            ->map
+            ->all()
+            ->each(function ($chunkOfAssetFiles) use ($assetPath, $vapor, $artifact, $fresh) {
+                $requests = $this->getAuthorizedAssetRequests(
+                    $vapor,
+                    $artifact,
+                    $chunkOfAssetFiles,
+                    $fresh,
+                );
 
-        $this->executeStoreAssetRequests($requests['store'], $assetPath);
-        $this->executeCopyAssetRequests($requests['copy'], $assetPath);
+                $this->executeStoreAssetRequests($requests['store'], $assetPath);
+                $this->executeCopyAssetRequests($requests['copy'], $assetPath);
 
-        $vapor->recordArtifactAssets(
-            $artifact['id'],
-            $assetFiles
-        );
+                $vapor->recordArtifactAssets(
+                    $artifact['id'],
+                    $chunkOfAssetFiles
+                );
+            });
     }
 
     /**
@@ -46,14 +53,19 @@ class ServeAssets
     {
         $storage = Helpers::app(AwsStorageProvider::class);
 
-        foreach ($requests as $request) {
-            Helpers::step('<comment>Uploading Asset:</comment> '.$request['path'].' ('.Helpers::kilobytes($assetPath.'/'.$request['path']).')');
+        if (! empty($requests)) {
+            try {
+                $storage->executeStoreRequests($requests, $assetPath, function ($request) use ($assetPath) {
+                    Helpers::step('<comment>Uploading Asset:</comment> '.$request['path'].' ('.Helpers::kilobytes($assetPath.'/'.$request['path']).')');
+                });
+            } catch (RequestFailedException $e) {
+                $request = $requests[$e->getIndex()];
 
-            $storage->store(
-                $request['url'],
-                array_merge($request['headers'], ['Cache-Control' => 'public, max-age=31536000']),
-                $assetPath.'/'.$request['path']
-            );
+                Helpers::line("<fg=red>Uploading:</> {$request['path']}");
+                Helpers::write($e->getMessage());
+
+                exit(1);
+            }
         }
     }
 
@@ -68,14 +80,12 @@ class ServeAssets
     {
         $storage = Helpers::app(AwsStorageProvider::class);
 
-        foreach ($requests as $request) {
-            Helpers::step('<fg=magenta>Copying Unchanged Asset:</> '.$request['path'].' ('.Helpers::kilobytes($assetPath.'/'.$request['path']).')');
-        }
-
         if (! empty($requests)) {
             try {
-                $storage->executeCopyRequests($requests);
-            } catch (CopyRequestFailedException $e) {
+                $storage->executeCopyRequests($requests, function () use ($assetPath) {
+                    Helpers::step('<fg=magenta>Copying Unchanged Asset:</> '.$request['path'].' ('.Helpers::kilobytes($assetPath.'/'.$request['path']).')');
+                });
+            } catch (RequestFailedException $e) {
                 $request = $requests[$e->getIndex()];
 
                 Helpers::line("<fg=red>Copying:</> {$request['path']}");


### PR DESCRIPTION
This pull request removes 400 public assets limitation and makes files uploads concurrent.

- The 400 public assets limitation is removed by applying pagination - using 400 elements - when reaching Vapor API. So, when asking the Vapor API for the store/copy signed URL, we lazy paginate over each 400 elements.
- Next, this pull request also contains code that makes files uploads concurrent, uploading **streaming** 10 files per S3 store object request.
- Finally, this pull request also provides store / copying feedback **in real-time** on the console.