### PR TITLE
Adds `default-environment` option

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -41,7 +41,7 @@ class BuildCommand extends Command
     {
         $this
             ->setName('build')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('asset-url', null, InputOption::VALUE_OPTIONAL, 'The asset base URL')
             ->addOption('build-arg', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build argument')
             ->setDescription('Build the project archive');

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -41,7 +41,7 @@ class BuildCommand extends Command
     {
         $this
             ->setName('build')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('asset-url', null, InputOption::VALUE_OPTIONAL, 'The asset base URL')
             ->addOption('build-arg', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build argument')
             ->setDescription('Build the project archive');

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -5,6 +5,7 @@ namespace Laravel\VaporCli\Commands;
 use DateTime;
 use Laravel\VaporCli\ConsoleVaporClient;
 use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
 use Laravel\VaporCli\Path;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Formatter\OutputFormatterStyle;
@@ -106,7 +107,13 @@ class Command extends SymfonyCommand
      */
     protected function argument($key)
     {
-        return $this->input->getArgument($key);
+        $value = $this->input->getArgument($key);
+
+        if ($key == 'environment' && is_null($value)) {
+            $value = Manifest::defaultEnvironment();
+        }
+
+        return $value;
     }
 
     /**

--- a/src/Commands/CommandCommand.php
+++ b/src/Commands/CommandCommand.php
@@ -19,7 +19,7 @@ class CommandCommand extends Command
     {
         $this
             ->setName('command')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('command', null, InputOption::VALUE_OPTIONAL, 'The command that should be executed')
             ->setDescription('Execute a CLI command');
     }

--- a/src/Commands/CommandCommand.php
+++ b/src/Commands/CommandCommand.php
@@ -19,7 +19,7 @@ class CommandCommand extends Command
     {
         $this
             ->setName('command')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('command', null, InputOption::VALUE_OPTIONAL, 'The command that should be executed')
             ->setDescription('Execute a CLI command');
     }

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -28,7 +28,7 @@ class DeployCommand extends Command
     {
         $this
             ->setName('deploy')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('commit', null, InputOption::VALUE_OPTIONAL, 'The commit hash that is being deployed')
             ->addOption('message', null, InputOption::VALUE_OPTIONAL, 'The message for the commit that is being deployed')
             ->addOption('without-waiting', null, InputOption::VALUE_NONE, 'Deploy without waiting for progress')

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -28,7 +28,7 @@ class DeployCommand extends Command
     {
         $this
             ->setName('deploy')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('commit', null, InputOption::VALUE_OPTIONAL, 'The commit hash that is being deployed')
             ->addOption('message', null, InputOption::VALUE_OPTIONAL, 'The message for the commit that is being deployed')
             ->addOption('without-waiting', null, InputOption::VALUE_NONE, 'Deploy without waiting for progress')

--- a/src/Commands/DeployListCommand.php
+++ b/src/Commands/DeployListCommand.php
@@ -18,7 +18,7 @@ class DeployListCommand extends Command
     {
         $this
             ->setName('deploy:list')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->setDescription('List the deployments for an environment');
     }
 

--- a/src/Commands/DeployListCommand.php
+++ b/src/Commands/DeployListCommand.php
@@ -18,7 +18,7 @@ class DeployListCommand extends Command
     {
         $this
             ->setName('deploy:list')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->setDescription('List the deployments for an environment');
     }
 

--- a/src/Commands/DownCommand.php
+++ b/src/Commands/DownCommand.php
@@ -20,7 +20,7 @@ class DownCommand extends Command
     {
         $this
             ->setName('down')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('secret', null, InputOption::VALUE_REQUIRED, 'The secret phrase that may be used to bypass maintenance mode')
             ->setDescription('Place an environment in maintenance mode');
     }

--- a/src/Commands/DownCommand.php
+++ b/src/Commands/DownCommand.php
@@ -20,7 +20,7 @@ class DownCommand extends Command
     {
         $this
             ->setName('down')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('secret', null, InputOption::VALUE_REQUIRED, 'The secret phrase that may be used to bypass maintenance mode')
             ->setDescription('Place an environment in maintenance mode');
     }

--- a/src/Commands/MetricsCommand.php
+++ b/src/Commands/MetricsCommand.php
@@ -17,7 +17,7 @@ class MetricsCommand extends Command
     {
         $this
             ->setName('metrics')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addArgument('period', InputArgument::OPTIONAL, 'The metric period (1m, 5m, 30m, 1h, 8h, 1d, 3d, 7d, 1M)', '1d')
             ->setDescription('Get usage and performance metrics for an environment');
     }

--- a/src/Commands/MetricsCommand.php
+++ b/src/Commands/MetricsCommand.php
@@ -17,7 +17,7 @@ class MetricsCommand extends Command
     {
         $this
             ->setName('metrics')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addArgument('period', InputArgument::OPTIONAL, 'The metric period (1m, 5m, 30m, 1h, 8h, 1d, 3d, 7d, 1M)', '1d')
             ->setDescription('Get usage and performance metrics for an environment');
     }

--- a/src/Commands/OpenCommand.php
+++ b/src/Commands/OpenCommand.php
@@ -17,7 +17,7 @@ class OpenCommand extends Command
     {
         $this
             ->setName('open')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->setDescription('Open an environment in your default browser');
     }
 

--- a/src/Commands/OpenCommand.php
+++ b/src/Commands/OpenCommand.php
@@ -17,7 +17,7 @@ class OpenCommand extends Command
     {
         $this
             ->setName('open')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->setDescription('Open an environment in your default browser');
     }
 

--- a/src/Commands/RedeployCommand.php
+++ b/src/Commands/RedeployCommand.php
@@ -19,7 +19,7 @@ class RedeployCommand extends Command
     {
         $this
             ->setName('redeploy')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->setDescription("Redeploy an environment's latest deployment");
     }
 

--- a/src/Commands/RedeployCommand.php
+++ b/src/Commands/RedeployCommand.php
@@ -19,7 +19,7 @@ class RedeployCommand extends Command
     {
         $this
             ->setName('redeploy')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->setDescription("Redeploy an environment's latest deployment");
     }
 

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -21,7 +21,7 @@ class RollbackCommand extends Command
     {
         $this
             ->setName('rollback')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('select', null, InputOption::VALUE_NONE, 'Present a list of deployments to choose from')
             ->setDescription('Rollback an environment to a previous deployment');
     }

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -21,7 +21,7 @@ class RollbackCommand extends Command
     {
         $this
             ->setName('rollback')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('select', null, InputOption::VALUE_NONE, 'Present a list of deployments to choose from')
             ->setDescription('Rollback an environment to a previous deployment');
     }

--- a/src/Commands/SecretCommand.php
+++ b/src/Commands/SecretCommand.php
@@ -18,7 +18,7 @@ class SecretCommand extends Command
     {
         $this
             ->setName('secret')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The secret name')
             ->addOption('value', null, InputOption::VALUE_OPTIONAL, 'The secret value')
             ->addOption('file', null, InputOption::VALUE_OPTIONAL, 'The file that contains the secret value')

--- a/src/Commands/SecretCommand.php
+++ b/src/Commands/SecretCommand.php
@@ -18,7 +18,7 @@ class SecretCommand extends Command
     {
         $this
             ->setName('secret')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The secret name')
             ->addOption('value', null, InputOption::VALUE_OPTIONAL, 'The secret value')
             ->addOption('file', null, InputOption::VALUE_OPTIONAL, 'The file that contains the secret value')

--- a/src/Commands/SecretDeleteCommand.php
+++ b/src/Commands/SecretDeleteCommand.php
@@ -18,7 +18,7 @@ class SecretDeleteCommand extends Command
     {
         $this
             ->setName('secret:delete')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The secret name')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Perform the action without confirmation')
             ->setDescription('Delete a secret from an environment');

--- a/src/Commands/SecretDeleteCommand.php
+++ b/src/Commands/SecretDeleteCommand.php
@@ -18,7 +18,7 @@ class SecretDeleteCommand extends Command
     {
         $this
             ->setName('secret:delete')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('name', null, InputOption::VALUE_OPTIONAL, 'The secret name')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Perform the action without confirmation')
             ->setDescription('Delete a secret from an environment');

--- a/src/Commands/SecretListCommand.php
+++ b/src/Commands/SecretListCommand.php
@@ -17,7 +17,7 @@ class SecretListCommand extends Command
     {
         $this
             ->setName('secret:list')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->setDescription('List the secrets for a given environment');
     }
 

--- a/src/Commands/SecretListCommand.php
+++ b/src/Commands/SecretListCommand.php
@@ -17,7 +17,7 @@ class SecretListCommand extends Command
     {
         $this
             ->setName('secret:list')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->setDescription('List the secrets for a given environment');
     }
 

--- a/src/Commands/SecretPassportCommand.php
+++ b/src/Commands/SecretPassportCommand.php
@@ -17,7 +17,7 @@ class SecretPassportCommand extends Command
     {
         $this
             ->setName('secret:passport')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->setDescription('Store the application\'s Passport keys as secrets');
     }
 

--- a/src/Commands/SecretPassportCommand.php
+++ b/src/Commands/SecretPassportCommand.php
@@ -17,7 +17,7 @@ class SecretPassportCommand extends Command
     {
         $this
             ->setName('secret:passport')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->setDescription('Store the application\'s Passport keys as secrets');
     }
 

--- a/src/Commands/TailCommand.php
+++ b/src/Commands/TailCommand.php
@@ -42,7 +42,7 @@ class TailCommand extends Command
     {
         $this
             ->setName('tail')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('filter', null, InputOption::VALUE_OPTIONAL, 'The text that should be used to filter the logs')
             ->addOption('cli', null, InputOption::VALUE_NONE, 'Tail the log for the CLI / queue function')
             ->addOption('without-queue', null, InputOption::VALUE_NONE, 'Hide Vapor generated queue processing messages')

--- a/src/Commands/TailCommand.php
+++ b/src/Commands/TailCommand.php
@@ -42,7 +42,7 @@ class TailCommand extends Command
     {
         $this
             ->setName('tail')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('filter', null, InputOption::VALUE_OPTIONAL, 'The text that should be used to filter the logs')
             ->addOption('cli', null, InputOption::VALUE_NONE, 'Tail the log for the CLI / queue function')
             ->addOption('without-queue', null, InputOption::VALUE_NONE, 'Hide Vapor generated queue processing messages')

--- a/src/Commands/TinkerCommand.php
+++ b/src/Commands/TinkerCommand.php
@@ -3,7 +3,6 @@
 namespace Laravel\VaporCli\Commands;
 
 use Laravel\VaporCli\Helpers;
-use Laravel\VaporCli\Manifest;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -18,7 +17,7 @@ class TinkerCommand extends CommandCommand
     {
         $this
             ->setName('tinker')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'The code to execute with Tinker')
             ->setDescription('Execute a code with Tinker');
     }

--- a/src/Commands/TinkerCommand.php
+++ b/src/Commands/TinkerCommand.php
@@ -3,6 +3,7 @@
 namespace Laravel\VaporCli\Commands;
 
 use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -17,7 +18,7 @@ class TinkerCommand extends CommandCommand
     {
         $this
             ->setName('tinker')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->addOption('code', null, InputOption::VALUE_OPTIONAL, 'The code to execute with Tinker')
             ->setDescription('Execute a code with Tinker');
     }

--- a/src/Commands/UpCommand.php
+++ b/src/Commands/UpCommand.php
@@ -19,7 +19,7 @@ class UpCommand extends Command
     {
         $this
             ->setName('up')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', 'staging')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
             ->setDescription('Remove an environment from maintenance mode');
     }
 

--- a/src/Commands/UpCommand.php
+++ b/src/Commands/UpCommand.php
@@ -19,7 +19,7 @@ class UpCommand extends Command
     {
         $this
             ->setName('up')
-            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name', Manifest::defaultEnvironment('default-environment'))
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->setDescription('Remove an environment from maintenance mode');
     }
 

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -56,6 +56,16 @@ class Manifest
     }
 
     /**
+     * Get the default environment of the project.
+     *
+     * @return string
+     */
+    public static function defaultEnvironment()
+    {
+        return static::current()['default-environment'] ?? 'staging';
+    }
+
+    /**
      * Get the Dockerfile for the given environment.
      *
      * @param  string  $environment


### PR DESCRIPTION
This pull request adds the `default-environment` option to the `vapor.yml` file. In other words, people can now set their default environment using the code bellow, and any command like `vapor deploy`, `vapor up`, `vapor secret:list`, will use the selected default environment instead of `staging`.

```yaml
id: 1
name: app
default-environment: production
environments:
    production:
        build:
            - 'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev'
    qa:
        build:
            - 'COMPOSER_MIRROR_PATH_REPOS=1 composer install'
```

This is useful, as there is a lot of people who don't have staging environment.