### PR TITLE
Make `environment` argument optional for env:pull and env:push commands

### DIFF
--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -17,7 +17,7 @@ class EnvPullCommand extends Command
     {
         $this
             ->setName('env:pull')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('file', null, InputArgument::OPTIONAL, 'File to write the environment variables to')
             ->setDescription('Download the environment file for the given environment');
     }

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -18,7 +18,7 @@ class EnvPushCommand extends Command
     {
         $this
             ->setName('env:push')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('file', null, InputOption::VALUE_OPTIONAL, 'File to upload the environment variables from')
             ->addOption('keep', null, InputOption::VALUE_NONE, 'Do not delete the environment file after pushing')
             ->setDescription('Upload the environment file for the given environment');


### PR DESCRIPTION
This is an extension of https://github.com/laravel/vapor-cli/pull/184. 

It means that the `env:pull` and `env:push` commands no longer need to provide the `environment` argument if the `vapor.yml` contains a `default-environment` value.