### PR TITLE
Output size of application before compression

### DIFF
--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -5,6 +5,7 @@ namespace Laravel\VaporCli\BuildProcess;
 use Laravel\VaporCli\BuiltApplicationFiles;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Manifest;
+use Laravel\VaporCli\Path;
 use Symfony\Component\Process\Process;
 use ZipArchive;
 
@@ -23,12 +24,15 @@ class CompressApplication
             return;
         }
 
-        Helpers::step('<options=bold>Compressing Application</>');
+        $appSizeInBytes = $this->getDirectorySize(Path::app());
+        $appSizeInMegabytes = round($appSizeInBytes / 1048576, 2);
+
+        Helpers::step('<options=bold>Compressing Application</> ('.$appSizeInMegabytes.'MB)');
 
         if (PHP_OS == 'Darwin') {
             $this->compressApplicationOnMac();
 
-            return $this->ensureArchiveIsWithinSizeLimits();
+            return $this->ensureArchiveIsWithinSizeLimits($appSizeInBytes);
         }
 
         $archive = new ZipArchive();
@@ -49,7 +53,7 @@ class CompressApplication
 
         $archive->close();
 
-        $this->ensureArchiveIsWithinSizeLimits();
+        $this->ensureArchiveIsWithinSizeLimits($appSizeInBytes);
     }
 
     /**
@@ -78,11 +82,12 @@ class CompressApplication
     /**
      * Ensure the application archive is within supported size limits.
      *
+     * @param float $bytes
      * @return void
      */
-    protected function ensureArchiveIsWithinSizeLimits()
+    protected function ensureArchiveIsWithinSizeLimits($bytes)
     {
-        $size = ceil($this->getDirectorySize($this->buildPath.'/app') / 1048576);
+        $size = ceil($bytes / 1048576);
 
         if ($size > 250) {
             Helpers::line();

--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -82,7 +82,7 @@ class CompressApplication
     /**
      * Ensure the application archive is within supported size limits.
      *
-     * @param  float $bytes
+     * @param  float  $bytes
      * @return void
      */
     protected function ensureArchiveIsWithinSizeLimits($bytes)

--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -82,7 +82,7 @@ class CompressApplication
     /**
      * Ensure the application archive is within supported size limits.
      *
-     * @param float $bytes
+     * @param  float $bytes
      * @return void
      */
     protected function ensureArchiveIsWithinSizeLimits($bytes)


### PR DESCRIPTION
- Provides useful feedback for the developer which is otherwise difficult to access without downloading and uncompressing the artifact from Lambda
- If I'm understanding correctly, the 250MB uncompressed limit includes the size of the custom Lambda runtime and any additional layers, so the check performed by ensureArchiveIsWithinSizeLimits may actually not be providing any useful value since the actual size of the uncompressed application plus the runtime and layers will be larger than the value being checked here
- This change doesn't address that issue but does at least provide feedback to the developer so that they can understand what effect their changes are having on the uncompressed size of their application
- Follows output format of subsequent step to keep output consistent in CLI
- Passes in archive size to ensureArchiveIsWithinSizeLimits via parameter to avoid doing the work of calculating the size twice

NOTES:

- The AWS Lambda docs specify MB as the unit for the size limits (50MB Archive size limit and 250MB Uncompressed size limit) whereas I believe the MB calculation for the output and size check in this file are both calculating MiB
- This may warrant another look if a way can be found to provide a more meaningful size check against the 250MB limit imposed by AWS