### PR TITLE
Inject the Vite asset url env variable

### DIFF
--- a/src/BuildProcess/SetBuildEnvironment.php
+++ b/src/BuildProcess/SetBuildEnvironment.php
@@ -77,5 +77,10 @@ class SetBuildEnvironment
             $envPath,
             'MIX_VAPOR_ASSET_URL='.$this->assetUrl.PHP_EOL
         );
+
+        $this->files->append(
+            $envPath,
+            'VITE_VAPOR_ASSET_URL='.$this->assetUrl.PHP_EOL
+        );
     }
 }


### PR DESCRIPTION
This exposes the asset URL env variable to give the same seamless experience currently available to Mix, meaning that users do not need to include `VITE_VAPOR_ASSET_URL=${ASSET_URL}` in the .env or any other env wrangling shenanigans.