### PR TITLE
Add command to invalidate asset cache

### DIFF
--- a/src/Commands/InvalidateAssetCacheCommand.php
+++ b/src/Commands/InvalidateAssetCacheCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Laravel\VaporCli\Helpers;
+use Laravel\VaporCli\Manifest;
+use Symfony\Component\Console\Input\InputArgument;
+
+class InvalidateAssetCacheCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('asset:invalidate-cache')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
+            ->setDescription('Invalidate the asset cache for the given environment');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Helpers::ensure_api_token_is_available();
+
+        $this->vapor->invalidateAssetCache(
+            Manifest::id(),
+            $this->argument('environment')
+        );
+
+        Helpers::info("Asset cache for {$this->argument('environment')} is being invalidated.");
+    }
+}

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1075,6 +1075,17 @@ class ConsoleVaporClient
     }
 
     /**
+     * Invalidate the asset cache for the given environment.
+     *
+     * @param  string  $environment
+     * @return array
+     */
+    public function invalidateAssetCache($projectId, $environment)
+    {
+        return $this->requestWithErrorHandling('post', '/api/projects/'.$projectId.'/environments/'.$environment.'/invalidate-assets');
+    }
+
+    /**
      * Get all of the deployments for the given project.
      *
      * @param  string  $projectId

--- a/vapor
+++ b/vapor
@@ -26,7 +26,6 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
  */
 (function () {
     if (class_exists(RepositoryBuilder::class)) {
-
         $adapters = [
             V4orV5EnvConstAdapter::class,
             V4orV5ServerConstAdapter::class,
@@ -56,7 +55,7 @@ if (file_exists(__DIR__.'/../../autoload.php')) {
         )->safeLoad();
     } else { // V3
         Dotenv::create(__DIR__, null, new DotenvFactory([
-            new V3EnvConstAdapter, new V3ServerConstAdapter
+            new V3EnvConstAdapter, new V3ServerConstAdapter,
         ]))->safeLoad();
     }
 })();
@@ -205,5 +204,8 @@ $app->add(new Commands\MetricsCommand);
 // Docker...
 $app->add(new Commands\LocalCommand);
 $app->add(new Commands\TestCommand);
+
+// Assets...
+$app->add(new Commands\InvalidateAssetCacheCommand);
 
 $app->run();


### PR DESCRIPTION
This PR adds a command to invalidate the CloudFront asset cache of a given environment.

On occasion, we see that assets such as fonts return CORs errors directly after a deployment. Sometimes, this can be resolved with a redeployment, but it's not guranteed and it's a slow process.

We have had success manually invalidating the CloudFront cache, but it's a cumbersome process.

Instead, this command can be used to create an [invalidation](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateInvalidation.html) of the files in CloudFront.

Using this command, only the directory related to the current environment is invalidated.