### PR TITLE
[1.x] Ignore `rr` binary

### DIFF
--- a/src/ApplicationFiles.php
+++ b/src/ApplicationFiles.php
@@ -18,6 +18,7 @@ class ApplicationFiles
                 ->in($path)
                 ->exclude('.idea')
                 ->exclude('.vapor')
+                ->notName('rr')
                 ->notPath('/^'.preg_quote('tests', '/').'/')
                 ->ignoreVcs(true)
                 ->ignoreDotFiles(false);


### PR DESCRIPTION
This pull request makes Vapor CLI ignore the `rr` binary that gets installed when using Octane and RoadRunner.