### PR TITLE
[1.x] Injects asset url on file

### DIFF
--- a/src/BuildProcess/CollectEnvironmentVariables.php
+++ b/src/BuildProcess/CollectEnvironmentVariables.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Laravel\VaporCli\BuildProcess;
+
+use Illuminate\Filesystem\Filesystem;
+use Laravel\VaporCli\Path;
+
+class CollectEnvironmentVariables
+{
+    use ParticipatesInBuildProcess;
+
+    /**
+     * The asset base URL.
+     */
+    protected $assetUrl;
+
+    /**
+     * Create a new project builder.
+     *
+     * @param  string|null  $assetUrl
+     * @return void
+     */
+    public function __construct($assetUrl = null)
+    {
+        $this->assetUrl = $assetUrl;
+
+        $this->appPath = Path::app();
+        $this->files = new Filesystem();
+    }
+
+    /**
+     * Execute the build process step.
+     *
+     * @return void
+     */
+    public function __invoke()
+    {
+        $environmentVariables = [
+            'ASSET_URL' => $this->assetUrl,
+            'MIX_URL' => $this->assetUrl,
+        ];
+
+        $this->files->put(
+            $this->appPath.'/vaporEnvironmentVariables.php',
+            '<?php return '.var_export($environmentVariables, true).';'
+        );
+    }
+}

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -4,6 +4,7 @@ namespace Laravel\VaporCli\Commands;
 
 use DateTime;
 use Laravel\VaporCli\BuildProcess\BuildContainerImage;
+use Laravel\VaporCli\BuildProcess\CollectEnvironmentVariables;
 use Laravel\VaporCli\BuildProcess\CollectSecrets;
 use Laravel\VaporCli\BuildProcess\CompressApplication;
 use Laravel\VaporCli\BuildProcess\CompressVendor;
@@ -83,6 +84,7 @@ class BuildCommand extends Command
             new ExtractAssetsToSeparateDirectory(),
             new InjectHandlers($this->argument('environment')),
             new CollectSecrets($this->argument('environment')),
+            new CollectEnvironmentVariables($this->option('asset-url')),
             new InjectErrorPages(),
             new InjectRdsCertificate(),
             new ExtractVendorToSeparateDirectory($this->argument('environment')),


### PR DESCRIPTION
This pull request injects the environment variables `ASSET_URL` and `MIX_URL` on the `vaporEnvironmentVariables` file so it gets consumed by https://github.com/laravel/vapor-core/pull/138.