### PR TITLE
Updates error messages

### DIFF
--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -52,7 +52,7 @@ class EnvPushCommand extends Command
         Helpers::line();
         Helpers::info('Environment variables uploaded successfully.');
         Helpers::line();
-        Helpers::line('You must deploy the project for the new variables to take effect.');
+        Helpers::line('You must deploy the project using the "deploy" command for the new variables to take effect.');
 
         if ($this->option('keep') !== true && Helpers::confirm('Would you like to delete the environment file from your machine')) {
             @unlink($file);

--- a/src/Commands/SecretCommand.php
+++ b/src/Commands/SecretCommand.php
@@ -42,7 +42,7 @@ class SecretCommand extends Command
         );
 
         Helpers::info('Secret stored successfully.');
-        Helpers::line('You should deploy the project to ensure the new secrets are available.');
+        Helpers::line('You should deploy the project using the "deploy" command to ensure the new secrets are available.');
     }
 
     /**

--- a/src/Commands/SecretPassportCommand.php
+++ b/src/Commands/SecretPassportCommand.php
@@ -39,7 +39,7 @@ class SecretPassportCommand extends Command
         $this->storePublicKey();
 
         Helpers::info('Keys stored successfully as secrets.');
-        Helpers::line('You should deploy the project to ensure the keys are available.');
+        Helpers::line('You should deploy the project using the "deploy" command to ensure the keys are available.');
     }
 
     /**

--- a/src/ConsoleVaporClient.php
+++ b/src/ConsoleVaporClient.php
@@ -1501,7 +1501,7 @@ class ConsoleVaporClient
         }
 
         if ($response->getStatusCode() === 404) {
-            Helpers::abort('The requested resource does not exist.');
+            Helpers::abort('The requested resource does not exist. Please ensure you are accessing the CLI with the correct team using the "team:current" command.');
         }
 
         if ($response->getStatusCode() === 409) {


### PR DESCRIPTION
The aim of this PR is to make it clear a full deployment from the CLI is required after updating secrets and environment variables as it won't suffice to "Redeploy" from the UI.

Additionally, it's common to see the error "The requested resource does not exist." when accessing the CLI using a team which doesn't own the resource being interacted with. It's not immediately obvious what this means, so this PR updates the error message in an attempt to point the user in the right direction.