### PR TITLE
Sets `LARAVEL_VAPOR` environment variable

### DIFF
--- a/src/BuildProcess/ExecuteBuildCommands.php
+++ b/src/BuildProcess/ExecuteBuildCommands.php
@@ -22,7 +22,7 @@ class ExecuteBuildCommands
         foreach (Manifest::buildCommands($this->environment) as $command) {
             Helpers::step('<comment>Running Command</comment>: '.$command);
 
-            $process = Process::fromShellCommandline($command, $this->appPath, null, null, null);
+            $process = Process::fromShellCommandline($command, $this->appPath, ['LARAVEL_VAPOR' => 1], null, null);
 
             $process->mustRun(function ($type, $line) {
                 Helpers::write($line);


### PR DESCRIPTION
This is an accompanying PR to  https://github.com/laravel/vite-plugin/pull/128

It sets the `LARAVEL_VAPOR` environment variable when executing the build commands of a deployment. 

`vite-plugin` looks for the presence of this variable and uses it to prevent the running of `npm run dev` during a deployment.

<img width="1009" alt="Screenshot 2022-09-07 at 10 34 44" src="https://user-images.githubusercontent.com/3438564/188845316-4e002c4f-87b2-4b8e-9a6f-61510b2a1a81.png">
