### PR TITLE
[1.x] Includes empty directories in build

### DIFF
--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -41,7 +41,7 @@ class CompressApplication
 
         foreach (BuiltApplicationFiles::get($this->appPath) as $file) {
             if ($file->isDir()) {
-                $this->processDirectory($file, $archive);
+                $this->copyEmptyDirectories($file, $archive);
 
                 continue;
             }
@@ -130,13 +130,13 @@ class CompressApplication
     }
 
     /**
-     * Process
+     * Copy empty directories into the archive.
      *
      * @param  \Symfony\Component\Finder\SplFileInfo  $file
      * @param  \ZipArchive  $archive
      * @return bool|void
      */
-    protected function processDirectory($file, $archive)
+    protected function copyEmptyDirectories($file, $archive)
     {
         if (! $file->isDir()) {
             return;

--- a/src/BuiltApplicationFiles.php
+++ b/src/BuiltApplicationFiles.php
@@ -16,7 +16,6 @@ class BuiltApplicationFiles
     {
         return (new Finder())
                 ->in($path)
-                ->files()
                 ->ignoreVcs(true)
                 ->ignoreDotFiles(false);
     }


### PR DESCRIPTION
This PR addresses an issue where empty directories are excluded when building an application on a non MacOS device.
