### PR TITLE
Added support for providing custom runtime.php within project

### DIFF
--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -27,7 +27,7 @@ class InjectHandlers
         if (Manifest::shouldSeparateVendor($this->environment)) {
             $this->files->copy($stubPath.'/runtime-with-vendor-download.php', $this->appPath.'/runtime.php');
         } else {
-            $this->files->copy($stubPath.'/runtime.php', $this->appPath.'/runtime.php');
+            $this->copyMissing($stubPath.'/runtime.php', $this->appPath.'/runtime.php');
         }
 
         $this->copyMissing($stubPath.'/cliRuntime.php', $this->appPath.'/cliRuntime.php');

--- a/src/BuildProcess/InjectHandlers.php
+++ b/src/BuildProcess/InjectHandlers.php
@@ -25,7 +25,7 @@ class InjectHandlers
         $stubPath = $this->appPath.'/vendor/laravel/vapor-core/stubs';
 
         if (Manifest::shouldSeparateVendor($this->environment)) {
-            $this->files->copy($stubPath.'/runtime-with-vendor-download.php', $this->appPath.'/runtime.php');
+            $this->copyMissing($stubPath.'/runtime-with-vendor-download.php', $this->appPath.'/runtime.php');
         } else {
             $this->copyMissing($stubPath.'/runtime.php', $this->appPath.'/runtime.php');
         }


### PR DESCRIPTION
This PR uses the `copyMissing()` method to provide `runtime.php` to the build. This allows for custom overrides of the autoloader import and additional logging.
