### PR TITLE
Add logout command

### DIFF
--- a/src/Commands/LogoutCommand.php
+++ b/src/Commands/LogoutCommand.php
@@ -26,7 +26,7 @@ class LogoutCommand extends Command
     public function handle()
     {
         $token = Helpers::config('token');
-        if(empty($token)) {
+        if (empty($token)) {
             Helpers::abort("You're not logged in.");
             return;
         }

--- a/src/Commands/LogoutCommand.php
+++ b/src/Commands/LogoutCommand.php
@@ -28,6 +28,7 @@ class LogoutCommand extends Command
         $token = Helpers::config('token');
         if (empty($token)) {
             Helpers::abort("You're not logged in.");
+
             return;
         }
 

--- a/src/Commands/LogoutCommand.php
+++ b/src/Commands/LogoutCommand.php
@@ -2,11 +2,7 @@
 
 namespace Laravel\VaporCli\Commands;
 
-use GuzzleHttp\Exception\ClientException;
-use Laravel\VaporCli\Config;
-use Laravel\VaporCli\Exceptions\NeedsTwoFactorAuthenticationTokenException;
 use Laravel\VaporCli\Helpers;
-use Psr\Http\Message\ResponseInterface;
 
 class LogoutCommand extends Command
 {

--- a/src/Commands/LogoutCommand.php
+++ b/src/Commands/LogoutCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use GuzzleHttp\Exception\ClientException;
+use Laravel\VaporCli\Config;
+use Laravel\VaporCli\Exceptions\NeedsTwoFactorAuthenticationTokenException;
+use Laravel\VaporCli\Helpers;
+use Psr\Http\Message\ResponseInterface;
+
+class LogoutCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('logout')
+            ->setDescription('Disassociate your Laravel Vapor account');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $token = Helpers::config('token');
+        if(empty($token)) {
+            Helpers::abort("You're not logged in.");
+            return;
+        }
+
+        Helpers::config(['token' => null]);
+
+        Helpers::info('Logged Out.'.PHP_EOL);
+    }
+}

--- a/vapor
+++ b/vapor
@@ -72,6 +72,7 @@ $app = new Application('Laravel Vapor', '1.44.0');
 
 // Authentication...
 $app->add(new Commands\LoginCommand);
+$app->add(new Commands\LogoutCommand);
 
 // Teams...
 $app->add(new Commands\TeamListCommand);


### PR DESCRIPTION
This PR adds a logout command to reset the stored token.

This is helpful when working with the Vapor CLI in different contexts (work & personal).