### PR TITLE
[1.x] Provide helpful error messaging for insufficient `.yml` options

### DIFF
--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -13,6 +13,10 @@ class Manifest
      */
     public static function id()
     {
+        if (! array_key_exists('id', static::current() ?? [])) {
+            Helpers::abort(sprintf('Invalid project ID. Please verify your Vapor manifest at [%s].', Path::manifest()));
+        }
+
         return static::current()['id'];
     }
 
@@ -23,6 +27,10 @@ class Manifest
      */
     public static function name()
     {
+        if (! array_key_exists('name', static::current() ?? [])) {
+            Helpers::abort(sprintf('Invalid project name. Please verify your Vapor manifest at [%s].', Path::manifest()));
+        }
+
         return static::current()['name'];
     }
 


### PR DESCRIPTION
When creating a blank `vapor.yml` file and attempting to deploy, you receive type errors: 

```
Warning: Trying to access array offset on value of type null in /laravel-app/vendor/laravel/vapor-cli/src/Manifest.php on line 16

Fatal error: Uncaught TypeError: Laravel\VaporCli\ConsoleVaporClient::validateManifest(): Argument #3 ($manifest) must be of type array, null given, called in /laravel-app/vendor/laravel/vapor-cli/src/Commands/DeployCommand.php on line 91 and defined in /laravel-app/vendor/laravel/vapor-cli/src/ConsoleVaporClient.php:1121
```

This PR provides a helpful error message when these values are missing. Also, don't create Vapor config files while eating breakfast. 😆 