### PR TITLE
[1.x] Adds secrets warning to CLI output

### DIFF
--- a/src/BuildProcess/CollectSecrets.php
+++ b/src/BuildProcess/CollectSecrets.php
@@ -26,6 +26,10 @@ class CollectSecrets
             return [$secret['name'] => $secret['version']];
         })->toArray();
 
+        if (! empty($secrets)) {
+            Helpers::warn('Using secrets may result in unexpected increased AWS billing charges. Instead, we recommend you utilize environment variables and / or encrypted environment files.');
+        }
+
         $this->files->put(
             $this->appPath.'/vaporSecrets.php',
             '<?php return '.var_export($secrets, true).';'

--- a/src/Commands/SecretCommand.php
+++ b/src/Commands/SecretCommand.php
@@ -34,6 +34,8 @@ class SecretCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
+        Helpers::warn('Using secrets may result in unexpected increased AWS billing charges. Instead, we recommend you utilize environment variables and / or encrypted environment files.');
+
         $this->vapor->storeSecret(
             Manifest::id(),
             $this->argument('environment'),

--- a/src/Commands/SecretListCommand.php
+++ b/src/Commands/SecretListCommand.php
@@ -30,6 +30,8 @@ class SecretListCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
+        Helpers::warn('Using secrets may result in unexpected increased AWS billing charges. Instead, we recommend you utilize environment variables and / or encrypted environment files.');
+
         $secrets = $this->vapor->secrets(
             Manifest::id(),
             $this->argument('environment')

--- a/src/Commands/SecretPassportCommand.php
+++ b/src/Commands/SecretPassportCommand.php
@@ -30,6 +30,8 @@ class SecretPassportCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
+        Helpers::warn('Using secrets may result in unexpected increased AWS billing charges. Instead, we recommend you utilize environment variables and / or encrypted environment files.');
+
         if (! file_exists(getcwd().'/storage/oauth-private.key') ||
             ! file_exists(getcwd().'/storage/oauth-public.key')) {
             Helpers::abort('Unable to find Passport keys in [storage] directory.');


### PR DESCRIPTION
This PR adds a warning to the output when interacting with secrets on the Vapor CLI. The warning is added:

- If secrets are found when collecting during the build (`vapor build` and `vapor deploy`)
- When adding a secret (`vapor secret`)
- When listing secrets (`vapor secret:list`)
- When adding passport secrets (`vapor secret:passport`)

<img width="740" alt="Screenshot 2022-11-23 at 14 46 09" src="https://user-images.githubusercontent.com/3438564/203576453-26a7f57c-1740-4385-9680-b1aa0a1360d9.png">

<img width="738" alt="Screenshot 2022-11-23 at 14 47 01" src="https://user-images.githubusercontent.com/3438564/203576458-c8f2ded8-e318-403b-99eb-97c37fb1b80d.png">

<img width="742" alt="Screenshot 2022-11-23 at 14 47 29" src="https://user-images.githubusercontent.com/3438564/203576460-e3818d70-3cc4-46e1-b133-e56f7c507cf3.png">

<img width="737" alt="Screenshot 2022-11-23 at 14 48 15" src="https://user-images.githubusercontent.com/3438564/203576461-4a92a692-3d37-46cf-b865-a032e76b6aba.png">
