### PR TITLE
Adds `env:passport` command

### DIFF
--- a/src/Commands/EnvPassportCommand.php
+++ b/src/Commands/EnvPassportCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Laravel\VaporCli\Commands;
+
+use Dotenv\Dotenv;
+use Dotenv\Exception\ExceptionInterface;
+use Laravel\VaporCli\Helpers;
+use Symfony\Component\Console\Input\InputArgument;
+
+class EnvPassportCommand extends Command
+{
+    /**
+     * Configure the command options.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('env:passport')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
+            ->setDescription('Store the application\'s Passport keys in the given environment file');
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! Helpers::confirm('Passport keys are too large to be stored directly as environment variables. You should only use this command if when using encrypted environments. Do you wish to continue?', false)) {
+            return static::FAILURE;
+        }
+
+        $environment = $this->argument('environment');
+        $environmentFile = '.env.'.$environment;
+
+        if (! file_exists(getcwd().'/'.$environmentFile)) {
+            Helpers::abort('Unable to find .env file for environment: '.$environment);
+        }
+
+        if (! file_exists(getcwd().'/storage/oauth-private.key') ||
+            ! file_exists(getcwd().'/storage/oauth-public.key')) {
+            Helpers::abort('Unable to find Passport keys in [storage] directory.');
+        }
+
+        $contents = file_get_contents(getcwd().'/'.$environmentFile);
+
+        try {
+            $variables = Dotenv::parse($contents);
+        } catch (ExceptionInterface $e) {
+            Helpers::abort('Unable to parse environment file: '.$environmentFile);
+        }
+
+        if (array_key_exists('PASSPORT_PRIVATE_KEY', $variables) || array_key_exists('PASSPORT_PRIVATE_KEY', $variables)) {
+            Helpers::abort('The environment file already contains Passport keys.');
+        }
+
+        $contents .= PHP_EOL.'PASSPORT_PRIVATE_KEY="'.file_get_contents(getcwd().'/storage/oauth-private.key').'"';
+        $contents .= PHP_EOL.'PASSPORT_PUBLIC_KEY="'.file_get_contents(getcwd().'/storage/oauth-public.key').'"';
+
+        file_put_contents(getcwd().'/'.$environmentFile, $contents);
+
+        Helpers::info('Keys successfully added to '.$environmentFile.'.');
+        Helpers::line('You should now encrypt the environment file using the "env:encrypt" command before redeploying your application.');
+    }
+}

--- a/src/Commands/EnvPassportCommand.php
+++ b/src/Commands/EnvPassportCommand.php
@@ -29,7 +29,7 @@ class EnvPassportCommand extends Command
      */
     public function handle()
     {
-        if (! Helpers::confirm('Passport keys are too large to be stored directly as environment variables. You should only use this command when using encrypted environments. Do you wish to continue?', false)) {
+        if (! Helpers::confirm('Passport keys are too large to be stored directly as environment variables. You should only use this command when using encrypted environments. Would you like to proceed?', false)) {
             return static::FAILURE;
         }
 

--- a/src/Commands/EnvPassportCommand.php
+++ b/src/Commands/EnvPassportCommand.php
@@ -29,7 +29,7 @@ class EnvPassportCommand extends Command
      */
     public function handle()
     {
-        if (! Helpers::confirm('Passport keys are too large to be stored directly as environment variables. You should only use this command if when using encrypted environments. Do you wish to continue?', false)) {
+        if (! Helpers::confirm('Passport keys are too large to be stored directly as environment variables. You should only use this command when using encrypted environments. Do you wish to continue?', false)) {
             return static::FAILURE;
         }
 

--- a/src/Commands/EnvPassportCommand.php
+++ b/src/Commands/EnvPassportCommand.php
@@ -29,7 +29,7 @@ class EnvPassportCommand extends Command
      */
     public function handle()
     {
-        if (! Helpers::confirm('Passport keys are too large to be stored directly as environment variables. You should only use this command when using encrypted environments. Would you like to proceed?', false)) {
+        if (! Helpers::confirm("Passport keys are too large to be stored as AWS Lambda environment variables. You should only use this command when using Laravel's encrypted environment files. Would you like to proceed?", false)) {
             return static::FAILURE;
         }
 

--- a/vapor
+++ b/vapor
@@ -161,6 +161,7 @@ $app->add(new Commands\ProjectListCommand);
 $app->add(new Commands\EnvListCommand);
 $app->add(new Commands\EnvCommand);
 $app->add(new Commands\EnvDescribeCommand);
+$app->add(new Commands\EnvPassportCommand);
 $app->add(new Commands\EnvPullCommand);
 $app->add(new Commands\EnvPushCommand);
 $app->add(new Commands\EnvCloneCommand);


### PR DESCRIPTION
This PR adds a command to add Passport keys to the customer's environment file. Passport keys are too large to be stored directly in the environment, so this command is to be used only in conjunction with encrypted environment files.

The command will:

- Prompt the user to confirm they are using encrypted envs
- Check the `.env.[ENV]` file exists
- Check the Passport keys exist
- Attempt to parse the `.env.[ENV]` file
- Check Passport keys don't already exist
- Append the keys to the `.env.[ENV]` file
- Prompt the user to use `env:encrypt` and redeploy

<img width="822" alt="Screenshot 2022-11-24 at 14 32 52" src="https://user-images.githubusercontent.com/3438564/203809022-dd884183-b64d-4a60-a230-e4a6fa2ae9b5.png">

<img width="819" alt="Screenshot 2022-11-24 at 14 32 08" src="https://user-images.githubusercontent.com/3438564/203809027-071b8dd7-f26e-4f8d-8322-f041e2e5ebdb.png">
