### PR TITLE
[1.x] Adds `domain`, `domain:list` and `domain:delete` aliases

### DIFF
--- a/src/Commands/ZoneCommand.php
+++ b/src/Commands/ZoneCommand.php
@@ -16,8 +16,9 @@ class ZoneCommand extends Command
     {
         $this
             ->setName('zone')
-            ->addArgument('zone', InputArgument::REQUIRED, 'The zone name')
-            ->setDescription('Create a new DNS zone');
+            ->setAliases(['domain'])
+            ->addArgument('domain', InputArgument::REQUIRED, 'The domain name')
+            ->setDescription('Add a domain to Vapor');
     }
 
     /**
@@ -30,11 +31,11 @@ class ZoneCommand extends Command
         Helpers::ensure_api_token_is_available();
 
         $zone = $this->vapor->createZone(
-            $this->determineProvider('Which cloud provider should the zone belong to?'),
-            $this->argument('zone')
+            $this->determineProvider('Which cloud provider should the domain belong to?'),
+            $this->argument('domain')
         );
 
-        Helpers::info('Zone created successfully.');
+        Helpers::info('Domain added successfully.');
         Helpers::line();
         Helpers::info('Nameservers:');
         Helpers::line();

--- a/src/Commands/ZoneCommand.php
+++ b/src/Commands/ZoneCommand.php
@@ -18,7 +18,7 @@ class ZoneCommand extends Command
             ->setName('zone')
             ->setAliases(['domain'])
             ->addArgument('domain', InputArgument::REQUIRED, 'The domain name')
-            ->setDescription('Add a domain to Vapor');
+            ->setDescription('Add a domain');
     }
 
     /**

--- a/src/Commands/ZoneDeleteCommand.php
+++ b/src/Commands/ZoneDeleteCommand.php
@@ -16,8 +16,9 @@ class ZoneDeleteCommand extends Command
     {
         $this
             ->setName('zone:delete')
-            ->addArgument('zone', InputArgument::REQUIRED, 'The zone name / ID')
-            ->setDescription('Delete a DNS zone');
+            ->setAliases(['domain:delete'])
+            ->addArgument('domain', InputArgument::REQUIRED, 'The domain name / ID')
+            ->setDescription('Delete a domain');
     }
 
     /**
@@ -27,22 +28,22 @@ class ZoneDeleteCommand extends Command
      */
     public function handle()
     {
-        $zone = $this->argument('zone');
-
-        if (! is_numeric($zoneId = $this->argument('zone'))) {
+        if (! is_numeric($zoneId = $this->argument('domain'))) {
             $zoneId = $this->findIdByName($this->vapor->zones(), $zoneId, 'zone');
         }
 
         if (is_null($zoneId)) {
-            Helpers::abort('Unable to find a zone with that name / ID.');
+            Helpers::abort('Unable to find a domain with that name / ID.');
         }
 
-        if (! Helpers::confirm("Are you sure you want to delete the zone for {$zone}", false)) {
+        $zone = $this->vapor->zone($zoneId);
+
+        if (! Helpers::confirm("Are you sure you want to delete [{$zone['zone']}] from Vapor", false)) {
             Helpers::abort('Action cancelled.');
         }
 
         $this->vapor->deleteZone($zoneId);
 
-        Helpers::info('Zone deleted successfully.');
+        Helpers::info('Domain successfully deleted from Vapor. Please note that the DNS zone will still persist on AWS.');
     }
 }

--- a/src/Commands/ZoneListCommand.php
+++ b/src/Commands/ZoneListCommand.php
@@ -15,7 +15,8 @@ class ZoneListCommand extends Command
     {
         $this
             ->setName('zone:list')
-            ->setDescription('List the DNS zones that belong to the current team');
+            ->setAliases(['domain:list'])
+            ->setDescription('List the domains that belong to the current team');
     }
 
     /**
@@ -28,7 +29,7 @@ class ZoneListCommand extends Command
         Helpers::ensure_api_token_is_available();
 
         $this->table([
-            'ID', 'Zone', 'Nameservers',
+            'ID', 'Domain', 'Nameservers',
         ], collect($this->vapor->zones())->map(function ($zone) {
             return [
                 $zone['id'],


### PR DESCRIPTION
This pull request replaces the terminology of Zone by Domain. In our Vapor Dashboard, we don't see the terminology Zone, and soon, I will pull request a new documentation that will equally not mention the term Zone that may be confusing for some people.

So, now people can use:

```
vapor domain example.com
vapor domain:list
vapor domain:delete example.com
```