### PR TITLE
[1.x] Uses PHP 8.2 by default

### DIFF
--- a/src/Commands/EnvCommand.php
+++ b/src/Commands/EnvCommand.php
@@ -46,7 +46,7 @@ class EnvCommand extends Command
         Manifest::addEnvironment($environment, [
             'memory'     => 1024,
             'cli-memory' => 512,
-            'runtime'    => $this->option('docker') ? 'docker' : 'php-8.1:al2',
+            'runtime'    => $this->option('docker') ? 'docker' : 'php-8.2:al2',
             'build'      => [
                 'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                 'php artisan event:cache',

--- a/src/Commands/LocalCommand.php
+++ b/src/Commands/LocalCommand.php
@@ -20,6 +20,7 @@ class LocalCommand extends Command
         '7.4' => 'laravelphp/vapor:php74',
         '8.0' => 'laravelphp/vapor:php80',
         '8.1' => 'laravelphp/vapor:php81',
+        '8.2' => 'laravelphp/vapor:php82',
     ];
 
     /**

--- a/src/Dockerfile.php
+++ b/src/Dockerfile.php
@@ -13,7 +13,7 @@ class Dockerfile
     public static function fresh($environment)
     {
         $content = <<<'Dockerfile'
-FROM laravelphp/vapor:php81
+FROM laravelphp/vapor:php82
 
 COPY . /var/task
 Dockerfile;

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -223,7 +223,7 @@ class Manifest
         $environments['production'] = array_filter([
             'memory' => 1024,
             'cli-memory' => 512,
-            'runtime' => 'php-8.1:al2',
+            'runtime' => 'php-8.2:al2',
             'build' => [
                 'COMPOSER_MIRROR_PATH_REPOS=1 composer install --no-dev',
                 'php artisan event:cache',
@@ -237,7 +237,7 @@ class Manifest
             $environments['staging'] = array_filter([
                 'memory' => 1024,
                 'cli-memory' => 512,
-                'runtime' => 'php-8.1:al2',
+                'runtime' => 'php-8.2:al2',
                 'build' => [
                     'COMPOSER_MIRROR_PATH_REPOS=1 composer install',
                     'php artisan event:cache',


### PR DESCRIPTION
This pull request makes Vapor CLI use PHP 8.2 by default.