### PR TITLE
[1.x] Filters build commands

### DIFF
--- a/tests/ExecuteBuildCommandsTest.php
+++ b/tests/ExecuteBuildCommandsTest.php
@@ -43,7 +43,7 @@ class ExecuteBuildCommandsTest extends TestCase
 
         $this->assertSame(
             ['php artisan migrate', 'php artisan optimize'],
-            (new ExecuteBuildCommands('production'))->supportedCommands(),
+            (new ExecuteBuildCommands('production'))->supportedCommands()
         );
     }
 }

--- a/tests/ExecuteBuildCommandsTest.php
+++ b/tests/ExecuteBuildCommandsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Laravel\VaporCli\Tests;
+
+use Illuminate\Container\Container;
+use Laravel\VaporCli\BuildProcess\ExecuteBuildCommands;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+class ExecuteBuildCommandsTest extends TestCase
+{
+    protected $testManifest;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        touch($this->testManifest = getcwd().'/test.vapor.yml');
+        Container::getInstance()->offsetSet('manifest', $this->testManifest);
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink(Container::getInstance()->offsetGet('manifest'));
+        parent::tearDown();
+    }
+
+    public function test_unsupported_commands_are_removed()
+    {
+        file_put_contents($this->testManifest, Yaml::dump([
+            'environments' => [
+                'production' => [
+                    'build' => [
+                        'pa clear-compiled',
+                        'php artisan migrate',
+                        'php artisan clear-compiled',
+                        'a optimize:clear',
+                        'php artisan optimize',
+                        'php artisan optimize:clear',
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertSame(
+            ['php artisan migrate', 'php artisan optimize'],
+            (new ExecuteBuildCommands('production'))->supportedCommands(),
+        );
+    }
+}


### PR DESCRIPTION
Removing the compiled services and packages file on deployment causes problems post-deployment.

When Laravel attempts to write the manifest when the application boots, we get an error as, in a Vapor environement, the directory is not writable.