### PR TITLE
Allow using custom ARM-based Docker images

### DIFF
--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -129,7 +129,7 @@ class BuildContainerImage
         }
 
         if (! Str::contains($contents, 'FROM laravelphp/vapor')) {
-            return false;
+            return true;
         }
 
         foreach ($buildArgs as $key => $value) {

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -122,13 +122,9 @@ class BuildContainerImage
     {
         $contents = file_get_contents(Path::dockerfile($environment));
 
-        if ($runtime === 'docker' && ! Str::contains($contents, 'FROM laravelphp/vapor')) {
+        if (in_array($runtime, ['docker', 'docker-arm']) && ! Str::contains($contents, 'FROM laravelphp/vapor')) {
             Helpers::warn('To ensure compatibility with the "docker" runtime, please make sure that your image is correctly configured for the x86 architecture.');
 
-            return true;
-        }
-
-        if (! Str::contains($contents, 'FROM laravelphp/vapor')) {
             return true;
         }
 

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -123,7 +123,8 @@ class BuildContainerImage
         $contents = file_get_contents(Path::dockerfile($environment));
 
         if (in_array($runtime, ['docker', 'docker-arm']) && ! Str::contains($contents, 'FROM laravelphp/vapor')) {
-            Helpers::warn('To ensure compatibility with the "docker" runtime, please make sure that your image is correctly configured for the x86 architecture.');
+            $arch = $runtime === 'docker' ? 'x86' : 'ARM';
+            Helpers::warn("To ensure compatibility with the \"{$runtime}\" runtime, please make sure that your image is correctly configured for the {$arch} architecture.");
 
             return true;
         }

--- a/tests/BuildContainerImageTest.php
+++ b/tests/BuildContainerImageTest.php
@@ -108,7 +108,7 @@ class BuildContainerImageTest extends TestCase
                 'docker-arm',
                 'FROM custom/image',
                 [],
-                false,
+                true,
             ],
             [
                 'docker',

--- a/tests/BuildContainerImageTest.php
+++ b/tests/BuildContainerImageTest.php
@@ -150,7 +150,7 @@ class BuildContainerImageTest extends TestCase
                 'docker-arm',
                 'FROM custom/vapor:php82',
                 [],
-                false,
+                true,
             ],
 
             // End of line tests...


### PR DESCRIPTION
This PR allows using custom ARM-based Docker images.

We always pre-build vapor image with extras (like Imagick extension), push it to AWS ECR then use that ECR image for deployments in `production.Dockerfile`. Disallowing custom ARM images prevents doing this.