### PR TITLE
[1.x] Allow for custom images when running docker-arm

### DIFF
--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -127,6 +127,12 @@ class BuildContainerImage
 
             return true;
         }
+        
+        if ($runtime === 'docker-arm' && ! Str::contains($contents, 'FROM laravelphp/vapor')) {
+            Helpers::warn('To ensure compatibility with the "docker-arm" runtime, please make sure that your image is correctly configured for the ARM architecture.');
+
+            return true;
+        }
 
         if (! Str::contains($contents, 'FROM laravelphp/vapor')) {
             return false;

--- a/tests/BuildContainerImageTest.php
+++ b/tests/BuildContainerImageTest.php
@@ -108,7 +108,7 @@ class BuildContainerImageTest extends TestCase
                 'docker-arm',
                 'FROM custom/image',
                 [],
-                false,
+                true,
             ],
             [
                 'docker',

--- a/tests/BuildContainerImageTest.php
+++ b/tests/BuildContainerImageTest.php
@@ -108,7 +108,7 @@ class BuildContainerImageTest extends TestCase
                 'docker-arm',
                 'FROM custom/image',
                 [],
-                true,
+                false,
             ],
             [
                 'docker',


### PR DESCRIPTION
Hello,
As a Vapor customer, I'd like to have the option to run my own custom docker image in the ARM architecture.

Since this option was already provided for the docker runtime this PR aims to add the same option to the docker arm runtime.