### PR TITLE
Hide environment keys / Add EnvironmentHasExceededLimit solution

### DIFF
--- a/src/Commands/Output/DeploymentFailure.php
+++ b/src/Commands/Output/DeploymentFailure.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\VaporCli\Commands\Output;
 
-use Illuminate\Support\Str;
 use Laravel\VaporCli\Commands\HookOutputCommand;
 use Laravel\VaporCli\ConsoleVaporClient;
 use Laravel\VaporCli\Helpers;
@@ -13,7 +12,6 @@ class DeploymentFailure
     /**
      * Render the output.
      *
-     * @param  \Laravel\VaporCli\Models\Deployment  $deployment
      * @return void
      */
     public function render(Deployment $deployment)
@@ -21,17 +19,9 @@ class DeploymentFailure
         Helpers::line('');
         Helpers::danger('    <bg=red;options=bold> Deployment Failed </>');
 
-        if ($message = $deployment->status_message) {
+        if ($deployment->status_message) {
             Helpers::line('');
-
-            $limitEnvironmentMessage = 'AWS: Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit';
-
-            $output = Str::contains($message, $limitEnvironmentMessage)
-                ? "    $limitEnvironmentMessage"
-                : "    $message";
-
-            Helpers::line('');
-            Helpers::line($output);
+            Helpers::line($deployment->formattedStatusMessage());
         }
 
         $deployment->solutions()->whenNotEmpty(function ($solutions) {

--- a/src/Commands/Output/DeploymentFailure.php
+++ b/src/Commands/Output/DeploymentFailure.php
@@ -20,10 +20,17 @@ class DeploymentFailure
         Helpers::line('');
         Helpers::danger('    <bg=red;options=bold> Deployment Failed </>');
 
-        if ($deployment->status_message) {
+        if ($message = $deployment->status_message) {
             Helpers::line('');
-            $message = $deployment->status_message;
-            Helpers::line("    $message");
+
+            $limitEnvironmentMessage = 'AWS: Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit';
+
+            $output = str_contains($message, $limitEnvironmentMessage)
+                ? "    $limitEnvironmentMessage"
+                : "    $message";
+
+            Helpers::line('');
+            Helpers::line($output);
         }
 
         $deployment->solutions()->whenNotEmpty(function ($solutions) {

--- a/src/Commands/Output/DeploymentFailure.php
+++ b/src/Commands/Output/DeploymentFailure.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\VaporCli\Commands\Output;
 
+use Illuminate\Support\Str;
 use Laravel\VaporCli\Commands\HookOutputCommand;
 use Laravel\VaporCli\ConsoleVaporClient;
 use Laravel\VaporCli\Helpers;
@@ -25,7 +26,7 @@ class DeploymentFailure
 
             $limitEnvironmentMessage = 'AWS: Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit';
 
-            $output = str_contains($message, $limitEnvironmentMessage)
+            $output = Str::contains($message, $limitEnvironmentMessage)
                 ? "    $limitEnvironmentMessage"
                 : "    $message";
 

--- a/src/Models/Deployment.php
+++ b/src/Models/Deployment.php
@@ -147,6 +147,7 @@ class Deployment
             Solutions\FunctionExceedsMaximumAllowedSize::class,
             Solutions\ResourceUpdateInProgress::class,
             Solutions\RunDeploymentHooksTimedOut::class,
+            Solutions\EnvironmentHasExceededLimit::class,
         ])->map(function ($solutionsClass) {
             return new $solutionsClass($this);
         })->filter

--- a/src/Models/Deployment.php
+++ b/src/Models/Deployment.php
@@ -153,7 +153,7 @@ class Deployment
             Solutions\FunctionExceedsMaximumAllowedSize::class,
             Solutions\ResourceUpdateInProgress::class,
             Solutions\RunDeploymentHooksTimedOut::class,
-            Solutions\EnvironmentHasExceededLimit::class,
+            Solutions\EnvironmentVariableLimitReached::class,
         ])->map(function ($solutionsClass) {
             return new $solutionsClass($this);
         })->filter

--- a/src/Models/Deployment.php
+++ b/src/Models/Deployment.php
@@ -45,10 +45,10 @@ class Deployment
                 return $step['status'] !== 'pending' &&
                        $step['status'] !== 'cancelled';
             })->map(function ($step) {
-                    return $this->formatDeploymentStepName($step['name']);
-                })->filter(function ($step) use ($displayedSteps) {
-                    return ! in_array($step, $displayedSteps);
-                })->all();
+                return $this->formatDeploymentStepName($step['name']);
+            })->filter(function ($step) use ($displayedSteps) {
+                return ! in_array($step, $displayedSteps);
+            })->all();
     }
 
     /**

--- a/src/Solutions/EnvironmentHasExceededLimit.php
+++ b/src/Solutions/EnvironmentHasExceededLimit.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Laravel\VaporCli\Solutions;
+
+use Illuminate\Support\Str;
+use Laravel\VaporCli\Deployment;
+
+class EnvironmentHasExceededLimit
+{
+    /**
+     * The deployment that have failed.
+     *
+     * @var \Laravel\VaporCli\Deployment
+     */
+    protected $deployment;
+
+    /**
+     * Create a new solution instance.
+     *
+     * @param  \Laravel\VaporCli\Deployment  $deployment
+     * @return void
+     */
+    public function __construct($deployment)
+    {
+        $this->deployment = $deployment;
+    }
+
+    /**
+     * Checks if the solution is applicable.
+     *
+     * @return bool
+     */
+    public function applicable()
+    {
+        return Str::contains($this->deployment->status_message, [
+            'Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit',
+        ]);
+    }
+
+    /**
+     * Returns the list of solutions based on the deployment.
+     *
+     * @return array
+     */
+    public function all()
+    {
+        return [
+            'You can use encrypted environment files in place of or in addition to environment variables: https://docs.vapor.build/1.0/projects/environments.html#encrypted-environment-files',
+            'You can also use the "Secrets" feature in conjunction with "Keys": https://vapor.laravel.com/app/projects/'.$this->deployment->project_id.'/environments/'.$this->deployment->environment['name'].'/secrets',
+        ];
+    }
+}

--- a/src/Solutions/EnvironmentVariableLimitReached.php
+++ b/src/Solutions/EnvironmentVariableLimitReached.php
@@ -5,7 +5,7 @@ namespace Laravel\VaporCli\Solutions;
 use Illuminate\Support\Str;
 use Laravel\VaporCli\Deployment;
 
-class EnvironmentHasExceededLimit
+class EnvironmentVariableLimitReached
 {
     /**
      * The deployment that have failed.
@@ -45,8 +45,7 @@ class EnvironmentHasExceededLimit
     public function all()
     {
         return [
-            'You can use encrypted environment files in place of or in addition to environment variables: https://docs.vapor.build/1.0/projects/environments.html#encrypted-environment-files',
-            'You can also use the "Secrets" feature in conjunction with "Keys": https://vapor.laravel.com/app/projects/'.$this->deployment->project_id.'/environments/'.$this->deployment->environment['name'].'/secrets',
+            'Use encrypted environment files in place of or in addition to environment variables: https://docs.vapor.build/1.0/projects/environments.html#encrypted-environment-files',
         ];
     }
 }

--- a/tests/SolutionsTest.php
+++ b/tests/SolutionsTest.php
@@ -67,4 +67,16 @@ class SolutionsTest extends TestCase
         $this->assertCount(2, $deployment->solutions());
         $this->assertStringContainsString('https://vapor.laravel.com/app/projects/1/environments/foo/logs', $deployment->solutions()[1]);
     }
+
+    public function test_environment_has_exceeded_limit()
+    {
+        $deployment = new Deployment([
+            'project_id' => 1,
+            'environment' => ['name' => 'foo'],
+            'status_message' => 'Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit',
+        ]);
+
+        $this->assertCount(2, $deployment->solutions());
+        $this->assertStringContainsString('https://vapor.laravel.com/app/projects/1/environments/foo/secrets', $deployment->solutions()[1]);
+    }
 }

--- a/tests/SolutionsTest.php
+++ b/tests/SolutionsTest.php
@@ -76,7 +76,7 @@ class SolutionsTest extends TestCase
             'status_message' => 'Lambda was unable to configure your environment variables because the environment variables you have provided exceeded the 4KB limit',
         ]);
 
-        $this->assertCount(2, $deployment->solutions());
-        $this->assertStringContainsString('https://vapor.laravel.com/app/projects/1/environments/foo/secrets', $deployment->solutions()[1]);
+        $this->assertCount(1, $deployment->solutions());
+        $this->assertStringContainsString('Use encrypted environment files in place of or in addition to environment variables', $deployment->solutions()[0]);
     }
 }


### PR DESCRIPTION
This Pull Request allows you to hide environment variables when they are executed by Lambda in more than 4kb in the deploy output. Validation is done by comparing the message returned in deploy.

A Solution has also been added for this case.

All keys are exposed from the text "**String measured**"

![image](https://github.com/laravel/vapor-cli/assets/33601626/b928b277-6701-460c-84c9-02a50f2b6be5)
