### PR TITLE
Allow to use custom asset domain without CloudFront

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -139,7 +139,7 @@ class DeployCommand extends Command
      */
     protected function assetDomain(array $project)
     {
-        if ($this->usesCloudFront() && $domain = $this->customAssetDomain()) {
+        if ($domain = $this->customAssetDomain()) {
             return "https://$domain";
         }
 


### PR DESCRIPTION
I would like to use different CDN provider than CloudFront but currently it's impossible to set custom domain if the `cloudfront` option is set to `false`. With this PR setting custom domain from other CDN providers that point directly to the s3 directory will be possible.