### PR TITLE
[1.x] Prevents running route:cache on build

### DIFF
--- a/src/BuildProcess/ExecuteBuildCommands.php
+++ b/src/BuildProcess/ExecuteBuildCommands.php
@@ -17,6 +17,7 @@ class ExecuteBuildCommands
     protected $unsupportedCommands = [
         'clear-compiled',
         'optimize:clear',
+        'route:cache',
     ];
 
     /**

--- a/tests/ExecuteBuildCommandsTest.php
+++ b/tests/ExecuteBuildCommandsTest.php
@@ -36,6 +36,7 @@ class ExecuteBuildCommandsTest extends TestCase
                         'a optimize:clear',
                         'php artisan optimize',
                         'php artisan optimize:clear',
+                        'php artisan route:cache',
                     ],
                 ],
             ],


### PR DESCRIPTION
Running `route:cache` during the build step of an application can cause an issue.

Routes will be serialized when running this command using the app key set in the build envrionment (local machine, CI, etc) as the signature.

If the same key is not set in production, an error will occur when attempting to deserialize after the app is deployed.