### PR TITLE
Add ability to specify args that will be passed to docker during the build

### DIFF
--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -45,6 +45,13 @@ class BuildContainerImage
     protected $cliBuildArgs;
 
     /**
+     * The Docker CLI arguments.
+     *
+     * @var array
+     */
+    protected $cliDockerArgs;
+
+    /**
      * The Docker manifest build arguments.
      *
      * @var array
@@ -55,13 +62,16 @@ class BuildContainerImage
      * Create a new project builder.
      *
      * @param  string|null  $environment
-     * @param  array  $buildArgs
+     * @param  array  $cliDockerArgs
+     * @param  array  $cliBuildArgs
+     * @param  array  $manifestBuildArgs
      * @return void
      */
-    public function __construct($environment = null, $cliBuildArgs = [], $manifestBuildArgs = [])
+    public function __construct($environment = null, $cliDockerArgs = [], $cliBuildArgs = [], $manifestBuildArgs = [])
     {
         $this->baseConstructor($environment);
 
+        $this->cliDockerArgs = $cliDockerArgs;
         $this->cliBuildArgs = $cliBuildArgs;
         $this->manifestBuildArgs = $manifestBuildArgs;
     }
@@ -96,6 +106,7 @@ class BuildContainerImage
             $this->appPath,
             Manifest::name(),
             $this->environment,
+            $this->cliDockerArgs,
             $this->formatBuildArguments()
         );
     }

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -49,7 +49,7 @@ class BuildContainerImage
      *
      * @var array
      */
-    protected $cliDockerOptions;
+    protected $cliBuildOptions;
 
     /**
      * The Docker manifest build arguments.
@@ -62,16 +62,16 @@ class BuildContainerImage
      * Create a new project builder.
      *
      * @param  string|null  $environment
-     * @param  array  $cliDockerOptions
+     * @param  array  $cliBuildOptions
      * @param  array  $cliBuildArgs
      * @param  array  $manifestBuildArgs
      * @return void
      */
-    public function __construct($environment = null, $cliDockerOptions = [], $cliBuildArgs = [], $manifestBuildArgs = [])
+    public function __construct($environment = null, $cliBuildOptions = [], $cliBuildArgs = [], $manifestBuildArgs = [])
     {
         $this->baseConstructor($environment);
 
-        $this->cliDockerOptions = $cliDockerOptions;
+        $this->cliBuildOptions = $cliBuildOptions;
         $this->cliBuildArgs = $cliBuildArgs;
         $this->manifestBuildArgs = $manifestBuildArgs;
     }
@@ -106,7 +106,7 @@ class BuildContainerImage
             $this->appPath,
             Manifest::name(),
             $this->environment,
-            $this->cliDockerOptions,
+            $this->cliBuildOptions,
             $this->formatBuildArguments()
         );
     }

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -45,11 +45,11 @@ class BuildContainerImage
     protected $cliBuildArgs;
 
     /**
-     * The Docker CLI arguments.
+     * The Docker CLI options.
      *
      * @var array
      */
-    protected $cliDockerArgs;
+    protected $cliDockerOptions;
 
     /**
      * The Docker manifest build arguments.
@@ -62,16 +62,16 @@ class BuildContainerImage
      * Create a new project builder.
      *
      * @param  string|null  $environment
-     * @param  array  $cliDockerArgs
+     * @param  array  $cliDockerOptions
      * @param  array  $cliBuildArgs
      * @param  array  $manifestBuildArgs
      * @return void
      */
-    public function __construct($environment = null, $cliDockerArgs = [], $cliBuildArgs = [], $manifestBuildArgs = [])
+    public function __construct($environment = null, $cliDockerOptions = [], $cliBuildArgs = [], $manifestBuildArgs = [])
     {
         $this->baseConstructor($environment);
 
-        $this->cliDockerArgs = $cliDockerArgs;
+        $this->cliDockerOptions = $cliDockerOptions;
         $this->cliBuildArgs = $cliBuildArgs;
         $this->manifestBuildArgs = $manifestBuildArgs;
     }
@@ -106,7 +106,7 @@ class BuildContainerImage
             $this->appPath,
             Manifest::name(),
             $this->environment,
-            $this->cliDockerArgs,
+            $this->cliDockerOptions,
             $this->formatBuildArguments()
         );
     }

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -62,17 +62,17 @@ class BuildContainerImage
      * Create a new project builder.
      *
      * @param  string|null  $environment
-     * @param  array  $cliBuildOptions
      * @param  array  $cliBuildArgs
+     * @param  array  $cliBuildOptions
      * @param  array  $manifestBuildArgs
      * @return void
      */
-    public function __construct($environment = null, $cliBuildOptions = [], $cliBuildArgs = [], $manifestBuildArgs = [])
+    public function __construct($environment = null, $cliBuildArgs = [], $cliBuildOptions = [], $manifestBuildArgs = [])
     {
         $this->baseConstructor($environment);
 
-        $this->cliBuildOptions = $cliBuildOptions;
         $this->cliBuildArgs = $cliBuildArgs;
+        $this->cliBuildOptions = $cliBuildOptions;
         $this->manifestBuildArgs = $manifestBuildArgs;
     }
 

--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -106,8 +106,8 @@ class BuildContainerImage
             $this->appPath,
             Manifest::name(),
             $this->environment,
-            $this->cliBuildOptions,
-            $this->formatBuildArguments()
+            $this->formatBuildArguments(),
+            $this->cliBuildOptions
         );
     }
 

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -40,7 +40,7 @@ class RemoveIgnoredFiles
             Path::app().'/.env.example',
             Path::app().'/.phpunit.result.cache',
             Path::app().'/package-lock.json',
-            // Path::app().'/phpunit.xml',
+            Path::app().'/phpunit.xml',
             Path::app().'/readme.md',
             Path::app().'/server.php',
             Path::app().'/storage/oauth-private.key',
@@ -132,10 +132,10 @@ class RemoveIgnoredFiles
                 $this->files->deleteDirectory($directory.'/'.$filePattern, $preserve = false);
             } else {
                 $files = (new Finder())
-                    ->in($directory)
-                    ->depth('== 0')
-                    ->ignoreDotFiles(false)
-                    ->name($filePattern);
+                            ->in($directory)
+                            ->depth('== 0')
+                            ->ignoreDotFiles(false)
+                            ->name($filePattern);
 
                 foreach ($files as $file) {
                     Helpers::step('<comment>Removing Ignored File:</comment> '.str_replace(Path::app().'/', '', $file->getRealPath()));

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -40,7 +40,7 @@ class RemoveIgnoredFiles
             Path::app().'/.env.example',
             Path::app().'/.phpunit.result.cache',
             Path::app().'/package-lock.json',
-            Path::app().'/phpunit.xml',
+            // Path::app().'/phpunit.xml',
             Path::app().'/readme.md',
             Path::app().'/server.php',
             Path::app().'/storage/oauth-private.key',
@@ -132,10 +132,10 @@ class RemoveIgnoredFiles
                 $this->files->deleteDirectory($directory.'/'.$filePattern, $preserve = false);
             } else {
                 $files = (new Finder())
-                            ->in($directory)
-                            ->depth('== 0')
-                            ->ignoreDotFiles(false)
-                            ->name($filePattern);
+                    ->in($directory)
+                    ->depth('== 0')
+                    ->ignoreDotFiles(false)
+                    ->name($filePattern);
 
                 foreach ($files as $file) {
                     Helpers::step('<comment>Removing Ignored File:</comment> '.str_replace(Path::app().'/', '', $file->getRealPath()));

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -91,8 +91,8 @@ class BuildCommand extends Command
             new CompressVendor($this->argument('environment')),
             new BuildContainerImage(
                 $this->argument('environment'),
-                $this->option('build-option'),
                 $this->option('build-arg'),
+                $this->option('build-option'),
                 Manifest::dockerBuildArgs($this->argument('environment'))
             ),
         ])->each->__invoke();

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -90,7 +90,7 @@ class BuildCommand extends Command
             new CompressVendor($this->argument('environment')),
             new BuildContainerImage(
                 $this->argument('environment'),
-                $this->option('docker-arg'),
+                $this->option('docker-option'),
                 $this->option('build-arg'),
                 Manifest::dockerBuildArgs($this->argument('environment'))
             ),

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -88,7 +88,12 @@ class BuildCommand extends Command
             new ExtractVendorToSeparateDirectory($this->argument('environment')),
             new CompressApplication($this->argument('environment')),
             new CompressVendor($this->argument('environment')),
-            new BuildContainerImage($this->argument('environment'), $this->option('build-arg'), Manifest::dockerBuildArgs($this->argument('environment'))),
+            new BuildContainerImage(
+                $this->argument('environment'),
+                $this->option('docker-arg'),
+                $this->option('build-arg'),
+                Manifest::dockerBuildArgs($this->argument('environment'))
+            ),
         ])->each->__invoke();
 
         $time = (new DateTime())->diff($startedAt)->format('%im%Ss');

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -45,6 +45,7 @@ class BuildCommand extends Command
             ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name')
             ->addOption('asset-url', null, InputOption::VALUE_OPTIONAL, 'The asset base URL')
             ->addOption('build-arg', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build argument')
+            ->addOption('build-option', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build option')
             ->setDescription('Build the project archive');
     }
 
@@ -90,7 +91,7 @@ class BuildCommand extends Command
             new CompressVendor($this->argument('environment')),
             new BuildContainerImage(
                 $this->argument('environment'),
-                $this->option('docker-option'),
+                $this->option('build-option'),
                 $this->option('build-arg'),
                 Manifest::dockerBuildArgs($this->argument('environment'))
             ),

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -34,6 +34,7 @@ class DeployCommand extends Command
             ->addOption('without-waiting', null, InputOption::VALUE_NONE, 'Deploy without waiting for progress')
             ->addOption('fresh-assets', null, InputOption::VALUE_NONE, 'Upload a fresh copy of all assets')
             ->addOption('build-arg', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build argument')
+            ->addOption('build-option', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Docker build option')
             ->addOption('debug', null, InputOption::VALUE_OPTIONAL, 'Deploy with debug mode enabled', 'unset')
             ->setDescription('Deploy an environment');
     }
@@ -123,6 +124,7 @@ class DeployCommand extends Command
             '--asset-url' => $this->assetDomain($project).'/'.$uuid,
             '--manifest' => Path::manifest(),
             '--build-arg' => $this->option('build-arg'),
+            '--build-option' => $this->option('build-option'),
         ]);
 
         return $this->uploadArtifact(

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -71,7 +71,7 @@ class Docker
                 })
                 ->merge(Collection::make($cliDockerArgs)
                     ->mapWithKeys(function ($value) {
-                        if (!str_contains($value, '=')) {
+                        if (! str_contains($value, '=')) {
                             return [$value => null];
                         }
 

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -14,11 +14,11 @@ class Docker
      * @param  string  $path
      * @param  string  $project
      * @param  string  $environment
-     * @param  array  $cliBuildOptions
      * @param  array  $cliBuildArgs
+     * @param  array  $cliBuildOptions
      * @return void
      */
-    public static function build($path, $project, $environment, $cliBuildOptions, $cliBuildArgs)
+    public static function build($path, $project, $environment, $cliBuildArgs, $cliBuildOptions)
     {
         $buildCommand = static::buildCommand(
             $project,

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -76,6 +76,7 @@ class Docker
                         }
 
                         [$key, $value] = explode('=', $value, 2);
+
                         return [$key => $value];
                     })
                 )->map(function ($value, $key) {

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -40,7 +40,8 @@ class Docker
      *
      * @param  string  $project
      * @param  string  $environment
-     * @param  array  $cliDockerBuildArgs
+     * @param  array  $cliDockerArgs
+     * @param  array  $manifestDockerArgs
      * @param  array  $cliBuildArgs
      * @param  array  $manifestBuildArgs
      * @return string

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -23,10 +23,10 @@ class Docker
         $buildCommand = static::buildCommand(
             $project,
             $environment,
-            $cliBuildOptions,
-            Manifest::dockerBuildOptions($environment),
             $cliBuildArgs,
-            Manifest::dockerBuildArgs($environment)
+            Manifest::dockerBuildArgs($environment),
+            $cliBuildOptions,
+            Manifest::dockerBuildOptions($environment)
         );
 
         Helpers::line(sprintf('Build command: %s', $buildCommand));
@@ -44,13 +44,13 @@ class Docker
      *
      * @param  string  $project
      * @param  string  $environment
-     * @param  array  $cliBuildOptions
-     * @param  array  $manifestBuildOptions
      * @param  array  $cliBuildArgs
      * @param  array  $manifestBuildArgs
+     * @param  array  $cliBuildOptions
+     * @param  array  $manifestBuildOptions
      * @return string
      */
-    public static function buildCommand($project, $environment, $cliBuildOptions, $manifestBuildOptions, $cliBuildArgs, $manifestBuildArgs)
+    public static function buildCommand($project, $environment, $cliBuildArgs, $manifestBuildArgs, $cliBuildOptions, $manifestBuildOptions)
     {
         $command = sprintf(
             'docker build --pull --file=%s --tag=%s ',

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -14,18 +14,18 @@ class Docker
      * @param  string  $path
      * @param  string  $project
      * @param  string  $environment
-     * @param  array  $cliDockerArgs
+     * @param  array  $cliDockerOptions
      * @param  array  $cliBuildArgs
      * @return void
      */
-    public static function build($path, $project, $environment, $cliDockerArgs, $cliBuildArgs)
+    public static function build($path, $project, $environment, $cliDockerOptions, $cliBuildArgs)
     {
         Process::fromShellCommandline(
             static::buildCommand(
                 $project,
                 $environment,
-                $cliDockerArgs,
-                Manifest::dockerArgs($environment),
+                $cliDockerOptions,
+                Manifest::dockerOptions($environment),
                 $cliBuildArgs,
                 Manifest::dockerBuildArgs($environment)
             ),
@@ -40,13 +40,13 @@ class Docker
      *
      * @param  string  $project
      * @param  string  $environment
-     * @param  array  $cliDockerArgs
-     * @param  array  $manifestDockerArgs
+     * @param  array  $cliDockerOptions
+     * @param  array  $manifestDockerOptions
      * @param  array  $cliBuildArgs
      * @param  array  $manifestBuildArgs
      * @return string
      */
-    public static function buildCommand($project, $environment, $cliDockerArgs, $manifestDockerArgs, $cliBuildArgs, $manifestBuildArgs)
+    public static function buildCommand($project, $environment, $cliDockerOptions, $manifestDockerOptions, $cliBuildArgs, $manifestBuildArgs)
     {
         return sprintf('docker build --pull --file=%s --tag=%s %s %s .',
             Manifest::dockerfile($environment),
@@ -61,7 +61,7 @@ class Docker
                 )->map(function ($value, $key) {
                     return '--build-arg='.escapeshellarg("{$key}={$value}").' ';
                 })->implode('')),
-            trim(Collection::make($manifestDockerArgs)
+            trim(Collection::make($manifestDockerOptions)
                 ->mapWithKeys(function ($value) {
                     if (is_array($value)) {
                         return $value;
@@ -69,7 +69,7 @@ class Docker
 
                     return [$value => null];
                 })
-                ->merge(Collection::make($cliDockerArgs)
+                ->merge(Collection::make($cliDockerOptions)
                     ->mapWithKeys(function ($value) {
                         if (! str_contains($value, '=')) {
                             return [$value => null];
@@ -81,10 +81,10 @@ class Docker
                     })
                 )->map(function ($value, $key) {
                     if ($value === null) {
-                        return "--${key} ";
+                        return "--{$key} ";
                     }
 
-                    return "--${key}=".escapeshellarg($value).' ';
+                    return "--{$key}=".escapeshellarg($value).' ';
                 })->implode(''))
         );
     }

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -62,13 +62,27 @@ class Docker
                     return '--build-arg='.escapeshellarg("{$key}={$value}").' ';
                 })->implode('')),
             trim(Collection::make($manifestDockerArgs)
+                ->mapWithKeys(function ($value) {
+                    if (is_array($value)) {
+                        return $value;
+                    }
+
+                    return [$value => null];
+                })
                 ->merge(Collection::make($cliDockerArgs)
                     ->mapWithKeys(function ($value) {
-                        [$key, $value] = explode('=', $value, 2);
+                        if (!str_contains($value, '=')) {
+                            return [$value => null];
+                        }
 
+                        [$key, $value] = explode('=', $value, 2);
                         return [$key => $value];
                     })
                 )->map(function ($value, $key) {
+                    if ($value === null) {
+                        return "--${key} ";
+                    }
+
                     return "--${key}=".escapeshellarg($value).' ';
                 })->implode(''))
         );

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -14,18 +14,18 @@ class Docker
      * @param  string  $path
      * @param  string  $project
      * @param  string  $environment
-     * @param  array  $cliDockerOptions
+     * @param  array  $cliBuildOptions
      * @param  array  $cliBuildArgs
      * @return void
      */
-    public static function build($path, $project, $environment, $cliDockerOptions, $cliBuildArgs)
+    public static function build($path, $project, $environment, $cliBuildOptions, $cliBuildArgs)
     {
         Process::fromShellCommandline(
             static::buildCommand(
                 $project,
                 $environment,
-                $cliDockerOptions,
-                Manifest::dockerOptions($environment),
+                $cliBuildOptions,
+                Manifest::dockerBuildOptions($environment),
                 $cliBuildArgs,
                 Manifest::dockerBuildArgs($environment)
             ),
@@ -40,13 +40,13 @@ class Docker
      *
      * @param  string  $project
      * @param  string  $environment
-     * @param  array  $cliDockerOptions
-     * @param  array  $manifestDockerOptions
+     * @param  array  $cliBuildOptions
+     * @param  array  $manifestBuildOptions
      * @param  array  $cliBuildArgs
      * @param  array  $manifestBuildArgs
      * @return string
      */
-    public static function buildCommand($project, $environment, $cliDockerOptions, $manifestDockerOptions, $cliBuildArgs, $manifestBuildArgs)
+    public static function buildCommand($project, $environment, $cliBuildOptions, $manifestBuildOptions, $cliBuildArgs, $manifestBuildArgs)
     {
         $command = sprintf(
             'docker build --pull --file=%s --tag=%s ', 
@@ -65,7 +65,7 @@ class Docker
                 return '--build-arg='.escapeshellarg("{$key}={$value}");
             })->implode(' ');
 
-        $dockerOptions = Collection::make($manifestDockerOptions)
+        $buildOptions = Collection::make($manifestBuildOptions)
             ->mapWithKeys(function ($value) {
                 if (is_array($value)) {
                     return $value;
@@ -73,7 +73,7 @@ class Docker
 
                 return [$value => null];
             })
-            ->merge(Collection::make($cliDockerOptions)
+            ->merge(Collection::make($cliBuildOptions)
                 ->mapWithKeys(function ($value) {
                     if (! str_contains($value, '=')) {
                         return [$value => null];
@@ -92,7 +92,7 @@ class Docker
             })->implode(' ');
 
         $command = $buildArgs ? $command.$buildArgs.' ' : $command;
-        $command = $dockerOptions ? $command.$dockerOptions.' ' : $command;
+        $command = $buildOptions ? $command.$buildOptions.' ' : $command;
         $command .= '.';
 
         return $command;

--- a/src/Docker.php
+++ b/src/Docker.php
@@ -20,15 +20,19 @@ class Docker
      */
     public static function build($path, $project, $environment, $cliBuildOptions, $cliBuildArgs)
     {
+        $buildCommand = static::buildCommand(
+            $project,
+            $environment,
+            $cliBuildOptions,
+            Manifest::dockerBuildOptions($environment),
+            $cliBuildArgs,
+            Manifest::dockerBuildArgs($environment)
+        );
+
+        Helpers::line(sprintf('Build command: %s', $buildCommand));
+
         Process::fromShellCommandline(
-            static::buildCommand(
-                $project,
-                $environment,
-                $cliBuildOptions,
-                Manifest::dockerBuildOptions($environment),
-                $cliBuildArgs,
-                Manifest::dockerBuildArgs($environment)
-            ),
+            $buildCommand,
             $path
         )->setTimeout(null)->mustRun(function ($type, $line) {
             Helpers::write($line);
@@ -49,7 +53,7 @@ class Docker
     public static function buildCommand($project, $environment, $cliBuildOptions, $manifestBuildOptions, $cliBuildArgs, $manifestBuildArgs)
     {
         $command = sprintf(
-            'docker build --pull --file=%s --tag=%s ', 
+            'docker build --pull --file=%s --tag=%s ',
             Manifest::dockerfile($environment),
             Str::slug($project).':'.$environment
         );

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -96,6 +96,17 @@ class Manifest
     }
 
     /**
+     * Get the Docker arguments.
+     *
+     * @param  string  $environment
+     * @return array
+     */
+    public static function dockerArgs($environment)
+    {
+        return static::current()['environments'][$environment]['docker-args'] ?? [];
+    }
+
+    /**
      * Determine if the environment uses a database proxy.
      *
      * @param  string  $environment

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -101,9 +101,9 @@ class Manifest
      * @param  string  $environment
      * @return array
      */
-    public static function dockerOptions($environment)
+    public static function dockerBuildOptions($environment)
     {
-        return static::current()['environments'][$environment]['docker-options'] ?? [];
+        return static::current()['environments'][$environment]['docker-build-options'] ?? [];
     }
 
     /**

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -96,14 +96,14 @@ class Manifest
     }
 
     /**
-     * Get the Docker arguments.
+     * Get the Docker options.
      *
      * @param  string  $environment
      * @return array
      */
-    public static function dockerArgs($environment)
+    public static function dockerOptions($environment)
     {
-        return static::current()['environments'][$environment]['docker-args'] ?? [];
+        return static::current()['environments'][$environment]['docker-options'] ?? [];
     }
 
     /**

--- a/tests/BuildContainerImageTest.php
+++ b/tests/BuildContainerImageTest.php
@@ -55,7 +55,7 @@ class BuildContainerImageTest extends TestCase
             ],
         ]));
 
-        $buildArgs = (new BuildContainerImage('production', [], ['FOO=BAR', 'BAR=BAZ']))->formatBuildArguments();
+        $buildArgs = (new BuildContainerImage('production', ['FOO=BAR', 'BAR=BAZ'], []))->formatBuildArguments();
 
         $this->assertSame(['__VAPOR_RUNTIME=docker', 'FOO=BAR', 'BAR=BAZ'], $buildArgs);
     }
@@ -72,7 +72,7 @@ class BuildContainerImageTest extends TestCase
             ],
         ]));
 
-        $buildArgs = (new BuildContainerImage('production', ['__VAPOR_RUNTIME=foo']))->formatBuildArguments();
+        $buildArgs = (new BuildContainerImage('production', [], ['__VAPOR_RUNTIME=foo']))->formatBuildArguments();
 
         $this->assertSame(['__VAPOR_RUNTIME=docker'], $buildArgs);
     }

--- a/tests/BuildContainerImageTest.php
+++ b/tests/BuildContainerImageTest.php
@@ -55,7 +55,7 @@ class BuildContainerImageTest extends TestCase
             ],
         ]));
 
-        $buildArgs = (new BuildContainerImage('production', ['FOO=BAR', 'BAR=BAZ']))->formatBuildArguments();
+        $buildArgs = (new BuildContainerImage('production', [], ['FOO=BAR', 'BAR=BAZ']))->formatBuildArguments();
 
         $this->assertSame(['__VAPOR_RUNTIME=docker', 'FOO=BAR', 'BAR=BAZ'], $buildArgs);
     }

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -57,19 +57,19 @@ class DockerTest extends TestCase
         $this->assertEquals($expectedCommand, $command);
     }
 
-    public function test_build_command_cli_docker_args()
+    public function test_build_command_cli_docker_options()
     {
-        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
-        $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, [], [], []);
+        $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
+        $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, [], [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
             "--BAR='FOO' --FIZZ='BAZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
 
-    public function test_build_command_manifest_docker_args()
+    public function test_build_command_manifest_docker_options()
     {
-        $manifestDockerArgs = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLE', 'BUZZLE'];
-        $command = Docker::buildCommand('my-project', 'production', [], $manifestDockerArgs, [], []);
+        $manifestDockerOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLE', 'BUZZLE'];
+        $command = Docker::buildCommand('my-project', 'production', [], $manifestDockerOptions, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
             "--FOO='BAR' --FIZZ='BUZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
@@ -77,19 +77,19 @@ class DockerTest extends TestCase
 
     public function test_build_command_cli_and_manifest_docker_args()
     {
-        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
-        $manifestDockerArgs = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLY', 'BUZZLY'];
-        $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, $manifestDockerArgs, [], []);
+        $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
+        $manifestDockerOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLY', 'BUZZLY'];
+        $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, $manifestDockerOptions, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
             "--FOO='BAR' --FIZZ='BAZZ' --FIZZLY --BUZZLY --BAR='FOO' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
 
-    public function test_build_command_cli_docker_args_and_cli_build_args()
+    public function test_build_command_cli_docker_options_and_cli_build_args()
     {
-        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
+        $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ'];
         $cliBuildArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
-        $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, [], $cliBuildArgs, []);
+        $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, [], $cliBuildArgs, []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--build-arg='BAR=FOO' --build-arg='FIZZ=BAZZ' --BAR='FOO' --FIZZ='BAZZ' .";
         $this->assertEquals($expectedCommand, $command);

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -24,26 +24,26 @@ class DockerTest extends TestCase
 
     public function test_build_command_no_build_args()
     {
-        $command = Docker::buildCommand('my-project', 'production', [], []);
-        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production .';
+        $command = Docker::buildCommand('my-project', 'production', [], [], [], [], []);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production   .';
         $this->assertEquals($expectedCommand, $command);
     }
 
     public function test_build_command_cli_build_args()
     {
         $cliBuildArgs = ['FOO=BAR', 'FIZZ=BUZZ'];
-        $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, []);
+        $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildArgs, []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
-            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ'  .";
         $this->assertEquals($expectedCommand, $command);
     }
 
     public function test_build_command_manifest_build_args()
     {
         $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
-        $command = Docker::buildCommand('my-project', 'production', [], $manifestBuildArgs);
+        $command = Docker::buildCommand('my-project', 'production', [], [], [], $manifestBuildArgs);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
-            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ'  .";
         $this->assertEquals($expectedCommand, $command);
     }
 
@@ -51,9 +51,47 @@ class DockerTest extends TestCase
     {
         $cliBuildArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
         $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
-        $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, $manifestBuildArgs);
+        $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildArgs, $manifestBuildArgs);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
-            "--build-arg='FOO=BAR' --build-arg='FIZZ=BAZZ' --build-arg='BAR=FOO' .";
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BAZZ' --build-arg='BAR=FOO'  .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_build_command_cli_docker_args()
+    {
+        $cliDockerArgs = ['FOO=BAR', 'FIZZ=BUZZ'];
+        $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, [], [], []);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
+            "--FOO='BAR' --FIZZ='BUZZ' .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_build_command_manifest_docker_args()
+    {
+        $manifestDockerArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
+        $command = Docker::buildCommand('my-project', 'production', [], $manifestDockerArgs, [], []);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
+            "--FOO='BAR' --FIZZ='BUZZ' .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_build_command_cli_and_manifest_docker_args()
+    {
+        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
+        $manifestDockerArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
+        $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, $manifestDockerArgs, [], []);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
+            "--FOO='BAR' --FIZZ='BAZZ' --BAR='FOO' .";
+        $this->assertEquals($expectedCommand, $command);
+    }
+
+    public function test_build_command_cli_docker_args_and_cli_build_args()
+    {
+        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
+        $cliBuildArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
+        $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, [], $cliBuildArgs, []);
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
+            "--build-arg='BAR=FOO' --build-arg='FIZZ=BAZZ' --BAR='FOO' --FIZZ='BAZZ' .";
         $this->assertEquals($expectedCommand, $command);
     }
 
@@ -69,8 +107,8 @@ class DockerTest extends TestCase
                 ],
             ],
         ]));
-        $command = Docker::buildCommand('my-project', 'production', [], []);
-        $expectedCommand = 'docker build --pull --file=docker/shared.Dockerfile --tag=my-project:production .';
+        $command = Docker::buildCommand('my-project', 'production', [], [], [], []);
+        $expectedCommand = 'docker build --pull --file=docker/shared.Dockerfile --tag=my-project:production   .';
         $this->assertEquals($expectedCommand, $command);
     }
 }

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -59,29 +59,29 @@ class DockerTest extends TestCase
 
     public function test_build_command_cli_docker_args()
     {
-        $cliDockerArgs = ['FOO=BAR', 'FIZZ=BUZZ'];
+        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
         $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, [], [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
-            "--FOO='BAR' --FIZZ='BUZZ' .";
+            "--BAR='FOO' --FIZZ='BAZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
 
     public function test_build_command_manifest_docker_args()
     {
-        $manifestDockerArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
+        $manifestDockerArgs = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLE', 'BUZZLE'];
         $command = Docker::buildCommand('my-project', 'production', [], $manifestDockerArgs, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
-            "--FOO='BAR' --FIZZ='BUZZ' .";
+            "--FOO='BAR' --FIZZ='BUZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
 
     public function test_build_command_cli_and_manifest_docker_args()
     {
-        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
-        $manifestDockerArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
+        $cliDockerArgs = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
+        $manifestDockerArgs = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLY', 'BUZZLY'];
         $command = Docker::buildCommand('my-project', 'production', $cliDockerArgs, $manifestDockerArgs, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
-            "--FOO='BAR' --FIZZ='BAZZ' --BAR='FOO' .";
+            "--FOO='BAR' --FIZZ='BAZZ' --FIZZLY --BUZZLY --BAR='FOO' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
 

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -59,8 +59,8 @@ class DockerTest extends TestCase
 
     public function test_build_command_cli_docker_options()
     {
-        $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
-        $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, [], [], []);
+        $cliBuildOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildOptions, [], [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--BAR='FOO' --FIZZ='BAZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
@@ -68,8 +68,8 @@ class DockerTest extends TestCase
 
     public function test_build_command_manifest_docker_options()
     {
-        $manifestDockerOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLE', 'BUZZLE'];
-        $command = Docker::buildCommand('my-project', 'production', [], $manifestDockerOptions, [], []);
+        $manifestBuildOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLE', 'BUZZLE'];
+        $command = Docker::buildCommand('my-project', 'production', [], $manifestBuildOptions, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--FOO='BAR' --FIZZ='BUZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
@@ -77,9 +77,9 @@ class DockerTest extends TestCase
 
     public function test_build_command_cli_and_manifest_docker_args()
     {
-        $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
-        $manifestDockerOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLY', 'BUZZLY'];
-        $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, $manifestDockerOptions, [], []);
+        $cliBuildOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
+        $manifestBuildOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLY', 'BUZZLY'];
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildOptions, $manifestBuildOptions, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--FOO='BAR' --FIZZ='BAZZ' --FIZZLY --BUZZLY --BAR='FOO' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
@@ -87,9 +87,9 @@ class DockerTest extends TestCase
 
     public function test_build_command_cli_docker_options_and_cli_build_args()
     {
-        $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ'];
+        $cliBuildOptions = ['BAR=FOO', 'FIZZ=BAZZ'];
         $cliBuildArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
-        $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, [], $cliBuildArgs, []);
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildOptions, [], $cliBuildArgs, []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--build-arg='BAR=FOO' --build-arg='FIZZ=BAZZ' --BAR='FOO' --FIZZ='BAZZ' .";
         $this->assertEquals($expectedCommand, $command);

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -24,7 +24,7 @@ class DockerTest extends TestCase
 
     public function test_build_command_no_build_args()
     {
-        $command = Docker::buildCommand('my-project', 'production', [], [], [], [], []);
+        $command = Docker::buildCommand('my-project', 'production', [], [], [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production .';
         $this->assertEquals($expectedCommand, $command);
     }
@@ -32,7 +32,7 @@ class DockerTest extends TestCase
     public function test_build_command_cli_build_args()
     {
         $cliBuildArgs = ['FOO=BAR', 'FIZZ=BUZZ'];
-        $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildArgs, []);
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, [], [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
         $this->assertEquals($expectedCommand, $command);
@@ -41,7 +41,7 @@ class DockerTest extends TestCase
     public function test_build_command_manifest_build_args()
     {
         $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
-        $command = Docker::buildCommand('my-project', 'production', [], [], [], $manifestBuildArgs);
+        $command = Docker::buildCommand('my-project', 'production', [], $manifestBuildArgs, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
         $this->assertEquals($expectedCommand, $command);
@@ -51,7 +51,7 @@ class DockerTest extends TestCase
     {
         $cliBuildArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
         $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
-        $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildArgs, $manifestBuildArgs);
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, $manifestBuildArgs, [], []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--build-arg='FOO=BAR' --build-arg='FIZZ=BAZZ' --build-arg='BAR=FOO' .";
         $this->assertEquals($expectedCommand, $command);
@@ -60,7 +60,7 @@ class DockerTest extends TestCase
     public function test_build_command_cli_docker_options()
     {
         $cliBuildOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
-        $command = Docker::buildCommand('my-project', 'production', $cliBuildOptions, [], [], []);
+        $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildOptions, []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--BAR='FOO' --FIZZ='BAZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
@@ -69,7 +69,7 @@ class DockerTest extends TestCase
     public function test_build_command_manifest_docker_options()
     {
         $manifestBuildOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLE', 'BUZZLE'];
-        $command = Docker::buildCommand('my-project', 'production', [], $manifestBuildOptions, [], []);
+        $command = Docker::buildCommand('my-project', 'production', [], [], [], $manifestBuildOptions);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--FOO='BAR' --FIZZ='BUZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
@@ -79,7 +79,7 @@ class DockerTest extends TestCase
     {
         $cliBuildOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
         $manifestBuildOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLY', 'BUZZLY'];
-        $command = Docker::buildCommand('my-project', 'production', $cliBuildOptions, $manifestBuildOptions, [], []);
+        $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildOptions, $manifestBuildOptions);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--FOO='BAR' --FIZZ='BAZZ' --FIZZLY --BUZZLY --BAR='FOO' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
@@ -89,7 +89,7 @@ class DockerTest extends TestCase
     {
         $cliBuildOptions = ['BAR=FOO', 'FIZZ=BAZZ'];
         $cliBuildArgs = ['BAR=FOO', 'FIZZ=BAZZ'];
-        $command = Docker::buildCommand('my-project', 'production', $cliBuildOptions, [], $cliBuildArgs, []);
+        $command = Docker::buildCommand('my-project', 'production', $cliBuildArgs, [], $cliBuildOptions, []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--build-arg='BAR=FOO' --build-arg='FIZZ=BAZZ' --BAR='FOO' --FIZZ='BAZZ' .";
         $this->assertEquals($expectedCommand, $command);

--- a/tests/DockerTest.php
+++ b/tests/DockerTest.php
@@ -25,7 +25,7 @@ class DockerTest extends TestCase
     public function test_build_command_no_build_args()
     {
         $command = Docker::buildCommand('my-project', 'production', [], [], [], [], []);
-        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production   .';
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production .';
         $this->assertEquals($expectedCommand, $command);
     }
 
@@ -34,7 +34,7 @@ class DockerTest extends TestCase
         $cliBuildArgs = ['FOO=BAR', 'FIZZ=BUZZ'];
         $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildArgs, []);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
-            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ'  .";
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
         $this->assertEquals($expectedCommand, $command);
     }
 
@@ -43,7 +43,7 @@ class DockerTest extends TestCase
         $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
         $command = Docker::buildCommand('my-project', 'production', [], [], [], $manifestBuildArgs);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
-            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ'  .";
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BUZZ' .";
         $this->assertEquals($expectedCommand, $command);
     }
 
@@ -53,7 +53,7 @@ class DockerTest extends TestCase
         $manifestBuildArgs = ['FOO' => 'BAR', 'FIZZ' => 'BUZZ'];
         $command = Docker::buildCommand('my-project', 'production', [], [], $cliBuildArgs, $manifestBuildArgs);
         $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
-            "--build-arg='FOO=BAR' --build-arg='FIZZ=BAZZ' --build-arg='BAR=FOO'  .";
+            "--build-arg='FOO=BAR' --build-arg='FIZZ=BAZZ' --build-arg='BAR=FOO' .";
         $this->assertEquals($expectedCommand, $command);
     }
 
@@ -61,7 +61,7 @@ class DockerTest extends TestCase
     {
         $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
         $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, [], [], []);
-        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--BAR='FOO' --FIZZ='BAZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
@@ -70,7 +70,7 @@ class DockerTest extends TestCase
     {
         $manifestDockerOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLE', 'BUZZLE'];
         $command = Docker::buildCommand('my-project', 'production', [], $manifestDockerOptions, [], []);
-        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--FOO='BAR' --FIZZ='BUZZ' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
@@ -80,7 +80,7 @@ class DockerTest extends TestCase
         $cliDockerOptions = ['BAR=FOO', 'FIZZ=BAZZ', 'FIZZLE', 'BUZZLE'];
         $manifestDockerOptions = [['FOO' => 'BAR'], ['FIZZ' => 'BUZZ'], 'FIZZLY', 'BUZZLY'];
         $command = Docker::buildCommand('my-project', 'production', $cliDockerOptions, $manifestDockerOptions, [], []);
-        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production  '.
+        $expectedCommand = 'docker build --pull --file=production.Dockerfile --tag=my-project:production '.
             "--FOO='BAR' --FIZZ='BAZZ' --FIZZLY --BUZZLY --BAR='FOO' --FIZZLE --BUZZLE .";
         $this->assertEquals($expectedCommand, $command);
     }
@@ -108,7 +108,7 @@ class DockerTest extends TestCase
             ],
         ]));
         $command = Docker::buildCommand('my-project', 'production', [], [], [], []);
-        $expectedCommand = 'docker build --pull --file=docker/shared.Dockerfile --tag=my-project:production   .';
+        $expectedCommand = 'docker build --pull --file=docker/shared.Dockerfile --tag=my-project:production .';
         $this->assertEquals($expectedCommand, $command);
     }
 }


### PR DESCRIPTION
This PR allows passing arguments to the `docker build` step.

We're using Buildx (that has been `installed`, which replaces `docker build` with `docker buildx build`). Buildx allows us to pass in additional parameters to the build command (for caching etc.).

This PR allows for docker args to be passed via the CLI:
```bash
--docker-arg="FOO=BAR" --docker-arg="FIZZ=BAR"
```

Or added to the manifest file:
```yaml
docker-args:
    FOO: BAR
    FIZZ: BAR
```