### PR TITLE
chore: use PHP 8.2 for `vapor local` by default

### DIFF
--- a/src/Commands/LocalCommand.php
+++ b/src/Commands/LocalCommand.php
@@ -128,7 +128,7 @@ class LocalCommand extends Command
                     ],
                 ],
                 'app' => [
-                    'image'      => static::$images[$this->option('php') ? $this->option('php') : '8.0'],
+                    'image'      => static::$images[$this->option('php') ? $this->option('php') : '8.2'],
                     'depends_on' => [
                         0 => 'mysql',
                         1 => 'redis',


### PR DESCRIPTION
Currently when `--php [version]` isn't provided, the default is `8.0`, which doesn't match the suggested changes in https://github.com/laravel/vapor-cli/pull/210