### PR TITLE
Fix Windows issue preventing compression when symbolic link is added …

### DIFF
--- a/src/BuildProcess/CompressApplication.php
+++ b/src/BuildProcess/CompressApplication.php
@@ -42,6 +42,10 @@ class CompressApplication
         foreach (BuiltApplicationFiles::get($this->appPath) as $file) {
             $relativePathName = str_replace('\\', '/', $file->getRelativePathname());
 
+            if (PHP_OS == "WINNT" && is_dir($relativePathName) && count(array_diff(stat($relativePathName), lstat($relativePathName))) > 0) {
+                continue;
+            }
+
             $archive->addFile($file->getRealPath(), $relativePathName);
 
             $archive->setExternalAttributesName(


### PR DESCRIPTION
When using the 'php artisan storage:link' command in the vapor.yml file, deploying or building on Windows becomes impossible as the application compression fails everytime. I added a check to avoid adding symbolic paths to the zip archive on Windows by verifying that we are on the Windows OS, that the file is a directory, and that it is a symbolic link. I used 'array_diff' because the 'is_link' function always returns false on Windows. See: https://bugs.php.net/bug.php?id=65697.