### PR TITLE
Update supported Docker images to match documentation

### DIFF
--- a/src/BuildProcess/BuildContainerImage.php
+++ b/src/BuildProcess/BuildContainerImage.php
@@ -26,6 +26,7 @@ class BuildContainerImage
         'laravelphp/vapor:php80',
         'laravelphp/vapor:php81',
         'laravelphp/vapor:php82',
+        'laravelphp/vapor:php83',
     ];
 
     /**
@@ -35,6 +36,7 @@ class BuildContainerImage
      */
     public static $armImages = [
         'laravelphp/vapor:php82-arm',
+        'laravelphp/vapor:php83-arm',
     ];
 
     /**

--- a/tests/BuildContainerImageTest.php
+++ b/tests/BuildContainerImageTest.php
@@ -190,7 +190,7 @@ class BuildContainerImageTest extends TestCase
                 'docker',
                 'FROM laravelphp/vapor:php83',
                 [],
-                false,
+                true,
             ],
             [
                 'docker-arm',
@@ -208,7 +208,7 @@ class BuildContainerImageTest extends TestCase
                 'docker-arm',
                 'FROM laravelphp/vapor:php83-arm',
                 [],
-                false,
+                true,
             ],
             [
                 'docker-arm',


### PR DESCRIPTION
I had to move a project runtime from `php-8.3:al2` to docker with php 8.3. The [documentation](https://docs.vapor.build/projects/environments.html#docker-runtimes) suggested this would be a direct migration, but it was resulting in the error message:

> The base image used in /REDACTED/vapor.Dockerfile is incompatible with the "docker" runtime, or you are running an outdated version of Vapor CLI.

Tracked this back to the documentation and the list of images in the CLI codebase being misaligned.

This PR matches the list expressed in the [Vapor documentation](https://docs.vapor.build/projects/environments.html#docker-runtimes) at the time of commit.