### PR TITLE
[1.x] Allow using `--force` on domain record deletion

### DIFF
--- a/src/Commands/RecordDeleteCommand.php
+++ b/src/Commands/RecordDeleteCommand.php
@@ -20,6 +20,7 @@ class RecordDeleteCommand extends Command
             ->addArgument('type', InputArgument::REQUIRED, 'The record type')
             ->addArgument('name', InputArgument::OPTIONAL, 'The record name')
             ->addArgument('value', InputArgument::OPTIONAL, 'The record value')
+            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion of the record without confirmation')
             ->setDescription('Delete a DNS record');
     }
 
@@ -30,7 +31,9 @@ class RecordDeleteCommand extends Command
      */
     public function handle()
     {
-        if (! Helpers::confirm('Are you sure you want to delete this record', false)) {
+        $forceDeletion = $this->option('force', false);
+        
+        if (! $forceDeletion && ! Helpers::confirm('Are you sure you want to delete this record', false)) {
             Helpers::abort('Action cancelled.');
         }
 


### PR DESCRIPTION
This PR adds a `force` option to the `record:delete` command to allow deleting records without confirmation. This is important when using the vapor-cli in CI/CD environments.