### PR TITLE
Abort if creating an environment called "testing"

### DIFF
--- a/src/Commands/EnvCommand.php
+++ b/src/Commands/EnvCommand.php
@@ -36,6 +36,10 @@ class EnvCommand extends Command
     {
         Helpers::ensure_api_token_is_available();
 
+        if ($this->argument('environment') === 'testing') {
+            Helpers::abort('Unable to create an environment called "testing"');
+        }
+
         $this->vapor->createEnvironment(
             Manifest::id(),
             $environment = $this->argument('environment'),

--- a/src/Commands/EnvCommand.php
+++ b/src/Commands/EnvCommand.php
@@ -37,7 +37,7 @@ class EnvCommand extends Command
         Helpers::ensure_api_token_is_available();
 
         if ($this->argument('environment') === 'testing') {
-            Helpers::abort('Unable to create an environment called "testing"');
+            Helpers::abort('This environment name is reserved by Vapor. Please choose another environment name.');
         }
 
         $this->vapor->createEnvironment(


### PR DESCRIPTION
This pull request notifies the user that we should avoid referring to an environment as "testing"

When calling the environment "testing", we may have problems during deployment if any code has the "`app()->runningUnitTests();`" check.

The problem is caused in the `SetBuildEnvironment` file on line 66 when doing this:

https://github.com/laravel/vapor-cli/blob/0563148b65b086975fb867a582659f5b90880a2b/src/BuildProcess/SetBuildEnvironment.php#L66

Therefore, if the user environment calls testing, steam will add `APP_ENV=testing` and the deployment will fail.

I don't believe it needs to change in "`SetBuildEnvironment`", why the name "**testing**" should be abolished instead of checking the environment.

I believe we also need to document