### PR TITLE
Defaults input shortcut values to null

### DIFF
--- a/src/Commands/DatabaseDeleteCommand.php
+++ b/src/Commands/DatabaseDeleteCommand.php
@@ -18,7 +18,7 @@ class DatabaseDeleteCommand extends Command
         $this
             ->setName('database:delete')
             ->addArgument('database', InputArgument::REQUIRED, 'The database name / ID')
-            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion of the database without confirmation')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force deletion of the database without confirmation')
             ->setDescription('Delete a database');
     }
 
@@ -29,7 +29,7 @@ class DatabaseDeleteCommand extends Command
      */
     public function handle()
     {
-        $forceDeletion = $this->option('force', false);
+        $forceDeletion = $this->option('force');
 
         if (! $forceDeletion && ! Helpers::confirm('Are you sure you want to delete this database', false)) {
             Helpers::abort('Action cancelled.');

--- a/src/Commands/EnvDeleteCommand.php
+++ b/src/Commands/EnvDeleteCommand.php
@@ -20,7 +20,7 @@ class EnvDeleteCommand extends Command
         $this
             ->setName('env:delete')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion of the environment without confirmation')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force deletion of the environment without confirmation')
             ->setDescription('Delete an environment');
     }
 
@@ -33,7 +33,7 @@ class EnvDeleteCommand extends Command
     {
         $environment = $this->argument('environment');
 
-        $forceDeletion = $this->option('force', false);
+        $forceDeletion = $this->option('force');
 
         if (! $forceDeletion && ! Helpers::confirm("Are you sure you want to delete the [{$environment}] environment", false)) {
             Helpers::abort('Action cancelled.');

--- a/src/Commands/RecordDeleteCommand.php
+++ b/src/Commands/RecordDeleteCommand.php
@@ -21,7 +21,7 @@ class RecordDeleteCommand extends Command
             ->addArgument('type', InputArgument::REQUIRED, 'The record type')
             ->addArgument('name', InputArgument::OPTIONAL, 'The record name')
             ->addArgument('value', InputArgument::OPTIONAL, 'The record value')
-            ->addOption('force', false, InputOption::VALUE_NONE, 'Force deletion of the record without confirmation')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force deletion of the record without confirmation')
             ->setDescription('Delete a DNS record');
     }
 
@@ -32,7 +32,7 @@ class RecordDeleteCommand extends Command
      */
     public function handle()
     {
-        $forceDeletion = $this->option('force', false);
+        $forceDeletion = $this->option('force');
 
         if (! $forceDeletion && ! Helpers::confirm('Are you sure you want to delete this record', false)) {
             Helpers::abort('Action cancelled.');


### PR DESCRIPTION
In verison 6.4.3 of Symfony console, the default value of shortcuts are no longer allowed to be `false`.

This PR addresses the issue relating to the `force` option of three commands and makes the option consistent with others in the package.