### PR TITLE
[1.x] Fixes CLI storage path for Laravel 11

### DIFF
--- a/src/BuildProcess/ConfigureArtisan.php
+++ b/src/BuildProcess/ConfigureArtisan.php
@@ -37,10 +37,10 @@ class ConfigureArtisan
                 '<?php',
                 "\$app = require_once __DIR__.'/bootstrap/app.php';",
                 "require __DIR__.'/vendor/autoload.php';",
-                <<<EOF
+                <<<'EOF'
 
 // Bootstrap Laravel and handle the command...
-\$status = (require_once __DIR__.'/bootstrap/app.php')
+$status = (require_once __DIR__.'/bootstrap/app.php')
     ->handleCommand(new ArgvInput);
 EOF
             ],

--- a/src/BuildProcess/ConfigureArtisan.php
+++ b/src/BuildProcess/ConfigureArtisan.php
@@ -37,11 +37,25 @@ class ConfigureArtisan
                 '<?php',
                 "\$app = require_once __DIR__.'/bootstrap/app.php';",
                 "require __DIR__.'/vendor/autoload.php';",
+                <<<EOF
+
+// Bootstrap Laravel and handle the command...
+\$status = (require_once __DIR__.'/bootstrap/app.php')
+    ->handleCommand(new ArgvInput);
+EOF
             ],
             [
                 '<?php'.PHP_EOL."ini_set('display_errors', '1');".PHP_EOL.'error_reporting(E_ALL);'.PHP_EOL,
                 "\$app = require_once __DIR__.'/bootstrap/app.php';".PHP_EOL.'$app->useStoragePath(Laravel\Vapor\Runtime\StorageDirectories::PATH);'.PHP_EOL,
                 Manifest::shouldSeparateVendor($this->environment) ? "require '/tmp/vendor/autoload.php';".PHP_EOL : "require __DIR__.'/vendor/autoload.php';".PHP_EOL,
+                <<<EOF
+// Bootstrap Laravel...
+\$app = require_once __DIR__.'/bootstrap/app.php';
+\$app->useStoragePath(Laravel\Vapor\Runtime\StorageDirectories::PATH);
+
+// Handle the command...
+\$status = \$app->handleCommand(new ArgvInput);
+EOF
             ],
             file_get_contents($file)
         );


### PR DESCRIPTION
When a project is built, Vapor CLI adjusts the contents of the `artisan` file to correctly set the storage path of the app.

This PR adjusts the artisan file for Laravel 11 as below:

```
#!/usr/bin/env php
<?php
ini_set('display_errors', '1');
error_reporting(E_ALL);


use Symfony\Component\Console\Input\ArgvInput;

define('LARAVEL_START', microtime(true));

// Register the Composer autoloader...
require __DIR__.'/vendor/autoload.php';

// Bootstrap Laravel...
$app = require_once __DIR__.'/bootstrap/app.php';
$app->useStoragePath(Laravel\Vapor\Runtime\StorageDirectories::PATH);

// Handle the command...
$status = $app->handleCommand(new ArgvInput);

exit($status);

```