### PR TITLE
Add frankenphp binary to IgnoredFiles while BuildProcess

### DIFF
--- a/src/ApplicationFiles.php
+++ b/src/ApplicationFiles.php
@@ -18,6 +18,7 @@ class ApplicationFiles
                 ->in($path)
                 ->exclude('.idea')
                 ->exclude('.vapor')
+                ->notName('frankenphp')
                 ->notName('rr')
                 ->notPath('/^'.preg_quote('tests', '/').'/')
                 ->ignoreVcs(true)

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -39,7 +39,6 @@ class RemoveIgnoredFiles
             Path::app().'/.env',
             Path::app().'/.env.example',
             Path::app().'/.phpunit.result.cache',
-            Path::app().'/frankenphp',
             Path::app().'/package-lock.json',
             Path::app().'/phpunit.xml',
             Path::app().'/readme.md',

--- a/src/BuildProcess/RemoveIgnoredFiles.php
+++ b/src/BuildProcess/RemoveIgnoredFiles.php
@@ -39,6 +39,7 @@ class RemoveIgnoredFiles
             Path::app().'/.env',
             Path::app().'/.env.example',
             Path::app().'/.phpunit.result.cache',
+            Path::app().'/frankenphp',
             Path::app().'/package-lock.json',
             Path::app().'/phpunit.xml',
             Path::app().'/readme.md',


### PR DESCRIPTION
While following the default installation-instructions of

- Octane (server frankenphp) for sail
- Vapor

You'll end up with the 'frankenphp' binary file in your application root. This file will be added to the Deployment Artifact resulting in a possible to big artifact for AWS Lambda. Resluting in a error while deploying:

```
Deployment Failed 
Your application exceeds the maximum size allowed by AWS Lambda.
```

This PR adds the binary to the ignored files while building the artifact