### PR TITLE
Add support for ignorefile when copying project

### DIFF
--- a/src/ApplicationFiles.php
+++ b/src/ApplicationFiles.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\VaporCli;
 
-use Illuminate\Support\Str;
 use Symfony\Component\Finder\Finder;
 
 class ApplicationFiles

--- a/src/ApplicationFiles.php
+++ b/src/ApplicationFiles.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\VaporCli;
 
+use Illuminate\Support\Str;
 use Symfony\Component\Finder\Finder;
 
 class ApplicationFiles
@@ -22,6 +23,7 @@ class ApplicationFiles
                 ->notName('rr')
                 ->notPath('/^'.preg_quote('tests', '/').'/')
                 ->ignoreVcs(true)
-                ->ignoreDotFiles(false);
+                ->ignoreDotFiles(false)
+                ->notPath(VaporIgnore::get()->toArray());
     }
 }

--- a/src/VaporIgnore.php
+++ b/src/VaporIgnore.php
@@ -58,6 +58,5 @@ class VaporIgnore
                     }
                 );
         }
-
     }
 }

--- a/src/VaporIgnore.php
+++ b/src/VaporIgnore.php
@@ -2,9 +2,7 @@
 
 namespace Laravel\VaporCli;
 
-use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use SplFileObject;
@@ -44,15 +42,15 @@ class VaporIgnore
         $line = trim($line);
 
         return Arr::map(match ($line) {
-            '', '#' => [], # ignore empty lines and comments
+            '', '#' => [], // ignore empty lines and comments
             default => glob("$baseDir/$line")
-        }, static function($line) use ($baseDir) {
+        }, static function ($line) use ($baseDir) {
             return Str::of($line)
                       ->after($baseDir)
                       ->trim('/')
-                      ->replace('/', '\/')
-                      ->prepend('/^')
-                      ->append('/')
+                      ->pipe(function ($line) {
+                          return '/^'.preg_quote($line, '/').'/';
+                      })
                       ->toString();
         });
     }

--- a/src/VaporIgnore.php
+++ b/src/VaporIgnore.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Laravel\VaporCli;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\LazyCollection;
+use Illuminate\Support\Str;
+use SplFileObject;
+
+class VaporIgnore
+{
+    public static function get(): LazyCollection
+    {
+        $path = getcwd().'/.vaporignore';
+
+        $baseDir = dirname($path);
+
+        return static::getLines($path)->map(function ($line) use ($baseDir) {
+            return static::parseLine($baseDir, trim($line));
+        })->flatten()->filter();
+    }
+
+    protected static function getLines($path): LazyCollection
+    {
+        return LazyCollection::make(function () use ($path) {
+            $file = new SplFileObject($path);
+
+            $file->setFlags(
+                SplFileObject::SKIP_EMPTY
+                | SplFileObject::READ_AHEAD
+                | SplFileObject::DROP_NEW_LINE
+            );
+
+            while (! $file->eof()) {
+                yield $file->fgets();
+            }
+        });
+    }
+
+    protected static function parseLine($baseDir, $line): false|array|null
+    {
+        $line = trim($line);
+
+        return Arr::map(match ($line) {
+            '', '#' => [], # ignore empty lines and comments
+            default => glob("$baseDir/$line")
+        }, static function($line) use ($baseDir) {
+            return Str::of($line)
+                      ->after($baseDir)
+                      ->trim('/')
+                      ->replace('/', '\/')
+                      ->prepend('/^')
+                      ->append('/')
+                      ->toString();
+        });
+    }
+}
+

--- a/src/VaporIgnore.php
+++ b/src/VaporIgnore.php
@@ -16,7 +16,7 @@ class VaporIgnore
         $baseDir = dirname($path);
 
         return static::getLines($path)->map(function ($line) use ($baseDir) {
-            return static::parseLine($baseDir,$line);
+            return static::parseLine($baseDir, $line);
         })->flatten()->filter();
     }
 
@@ -45,15 +45,18 @@ class VaporIgnore
             case '#':
                 return [];
             default:
-                return Arr::map(glob($baseDir.'/'.trim($line, '/')), function ($path) use ($baseDir) {
-                    return Str::of($path)
-                              ->after($baseDir)
-                              ->trim('/')
-                              ->pipe(function ($line) {
-                                  return '/^'.preg_quote($line, '/').'/';
-                              })
-                              ->toString();
-                });
+                return Arr::map(
+                    glob($baseDir.'/'.trim($line, '/')),
+                    function ($path) use ($baseDir) {
+                        return Str::of($path)
+                                  ->after($baseDir)
+                                  ->trim('/')
+                                  ->pipe(function ($line) {
+                                      return '/^'.preg_quote($line, '/').'/';
+                                  })
+                                  ->toString();
+                    }
+                );
         }
 
     }


### PR DESCRIPTION
This PR adds support for a `.vaporignore` file that lets you control what files are copied over to the `.vapor` build folder.

### Background

I have a project with a DDD-structure as is pretty common with Laravel nowdays. We recently started to put test files inside each domain and that causes problems with the domian autoloader we have. It scans though the domain code and when i loads the test files we get an error that the `TestCase` file can't be found becuase the whole `/test` directory is not copied to the `.vapor` build folder.

While this is a very specific problem that can be solved in other ways, I got the idea to make vapor support an ignore file that lets you control what files are copied over to the `.vapor` build folder.

### Why
- This lets you control what files are copied and what files will be bundled in the artifact that is uploaded to AWS. It is important to try to keep the artifact small to save money and you might also not need to build a docker container if you can ignore more files. 
- This significantly speeds up the deploys. The copying step in our application when down from about 10-12 seconds to 1 second or less (we have some SQL dumps that I think slows things down a bit). The later steps for uploading is obviously also faster but I haven't benchmarked that. 
- It saves some disk space. 

### Other considerations
Maybe the `.idea` and `/tests` excludes in `ApplicationFiles` should be removed as well to let the user control this, but that would probably be considered a breaking change. We could add this as a default if no `.vaporignore` file is found to keep the current behavior. Maybe the same could go for the other lines in there as well, such as `frankenphp`, `rr`(roadrunner)

### TODO
Write documentation, and maybe provide an example file/stub that can be published. I can write this if this gets accepted. 
I would also like to add some tests, but that would require `orchestral/testbench` to make a proper test setup with ignore file.

-----

**This is what the `.vaporignore` looks like in our project:**

```
/tests/
/src/Domains/*/Tests/
/src/Domains/*/Database/Seeds/
/docs
/.run
/.github
/.phpunt.cache
/reports
/scripts
/stubs
/http

/database/dumps
/database/schema
/database/sql
``` 