### PR TITLE
[1.x] Allow force deleting vanity domain without confirmation

### DIFF
--- a/src/Commands/VanityDomainDeleteCommand.php
+++ b/src/Commands/VanityDomainDeleteCommand.php
@@ -5,6 +5,7 @@ namespace Laravel\VaporCli\Commands;
 use Laravel\VaporCli\Helpers;
 use Laravel\VaporCli\Manifest;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class VanityDomainDeleteCommand extends Command
 {

--- a/src/Commands/VanityDomainDeleteCommand.php
+++ b/src/Commands/VanityDomainDeleteCommand.php
@@ -18,6 +18,7 @@ class VanityDomainDeleteCommand extends Command
         $this
             ->setName('vanity-domain:delete')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force deletion of the vanity domain without confirmation')
             ->setDescription('Delete the vanity domain associated with the given environment');
     }
 
@@ -29,8 +30,9 @@ class VanityDomainDeleteCommand extends Command
     public function handle()
     {
         $environment = $this->argument('environment');
+        $forceDeletion = $this->option('force');
 
-        if (! Helpers::confirm("Are you sure you want to delete the vanity domain of the [{$environment}] environment", false)) {
+        if (! $forceDeletion && ! Helpers::confirm("Are you sure you want to delete the vanity domain of the [{$environment}] environment", false)) {
             Helpers::abort('Action cancelled.');
         }
 


### PR DESCRIPTION
In our project, we never use vanity domains. Since Vapor always creates vanity domains for each environment we want to delete them immediately after deployment. Adding the `--force` option would allow us to run this command in CI without confirmation.

Also, maybe it would be a good idea to allow Vapor YAML to skip vanity domains completely with something like `vanity-domain: false` for the environment. If you agree, I can propose a PR for it.