### PR TITLE
Fixing PHP 8.4 deprecation warning

### DIFF
--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -39,7 +39,7 @@ class AwsStorageProvider
      * @param  string  $url
      * @param  array  $headers
      * @param  string  $file
-     * @param  bool  $progress
+     * @param  bool  $withProgress
      * @return void
      */
     public function store($url, array $headers, $file, $withProgress = false)
@@ -184,7 +184,7 @@ class AwsStorageProvider
     {
         $stack = HandlerStack::create();
 
-        $stack->push(Middleware::retry(function (int $retries, RequestInterface $request, ResponseInterface $response = null) {
+        $stack->push(Middleware::retry(function (int $retries, RequestInterface $request, ?ResponseInterface $response = null) {
             $text = '<comment>Retrying Request: </comment><options=bold>'.$request->getMethod().'</> '.Str::before($request->getUri(), '?');
 
             if ($retries === 0) {


### PR DESCRIPTION
PHP Deprecated:  {closure:Laravel\VaporCli\Aws\AwsStorageProvider::retryHandler():187}(): Implicitly marking parameter $response as nullable is deprecated, the explicit nullable type must be used instead in /some/path/vendor/laravel/vapor-cli/src/Aws/AwsStorageProvider.php on line 187