### PR TITLE
Fix S3 http requests always retrying once on success

### DIFF
--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -187,12 +187,6 @@ class AwsStorageProvider
         $stack->push(Middleware::retry(function (int $retries, RequestInterface $request, ?ResponseInterface $response = null) {
             $text = '<comment>Retrying Request: </comment><options=bold>'.$request->getMethod().'</> '.Str::before($request->getUri(), '?');
 
-            if ($retries === 0) {
-                Helpers::step($text);
-
-                return true;
-            }
-
             if ($response && $response->getStatusCode() < 300) {
                 return false;
             }


### PR DESCRIPTION
Guzzle's retry middleware is called regardless of whether the request was successful or failed. `$retries` is always going to be `0` on the first call of the middleware. This check is causing requests to retry once, even if the request to S3 was successful.