### PR TITLE
Fix Symfony Console v8 compatibility

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -2,8 +2,8 @@
 
 namespace Laravel\VaporCli;
 
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Application as SymfonyConsoleApplication;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 

--- a/src/Application.php
+++ b/src/Application.php
@@ -2,12 +2,28 @@
 
 namespace Laravel\VaporCli;
 
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Application as SymfonyConsoleApplication;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputOption;
 
 class Application extends SymfonyConsoleApplication
 {
+    /**
+     * Adds a command object.
+     *
+     * Symfony Console v8 renamed add() to addCommand(). This override
+     * ensures the vapor entrypoint works across Symfony 4–8.
+     */
+    public function add(Command $command): ?Command
+    {
+        if (method_exists(parent::class, 'add')) {
+            return parent::add($command);
+        }
+
+        return $this->addCommand($command);
+    }
+
     protected function getDefaultInputDefinition(): InputDefinition
     {
         $definition = parent::getDefaultInputDefinition();

--- a/src/Commands/BalancerCommand.php
+++ b/src/Commands/BalancerCommand.php
@@ -12,7 +12,7 @@ class BalancerCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('balancer')

--- a/src/Commands/BalancerDeleteCommand.php
+++ b/src/Commands/BalancerDeleteCommand.php
@@ -12,7 +12,7 @@ class BalancerDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('balancer:delete')

--- a/src/Commands/BalancerListCommand.php
+++ b/src/Commands/BalancerListCommand.php
@@ -11,7 +11,7 @@ class BalancerListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('balancer:list')

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -38,7 +38,7 @@ class BuildCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('build')

--- a/src/Commands/CacheCommand.php
+++ b/src/Commands/CacheCommand.php
@@ -13,7 +13,7 @@ class CacheCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache')

--- a/src/Commands/CacheDeleteCommand.php
+++ b/src/Commands/CacheDeleteCommand.php
@@ -12,7 +12,7 @@ class CacheDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache:delete')

--- a/src/Commands/CacheListCommand.php
+++ b/src/Commands/CacheListCommand.php
@@ -12,7 +12,7 @@ class CacheListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache:list')

--- a/src/Commands/CacheMetricsCommand.php
+++ b/src/Commands/CacheMetricsCommand.php
@@ -12,7 +12,7 @@ class CacheMetricsCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache:metrics')

--- a/src/Commands/CacheScaleCommand.php
+++ b/src/Commands/CacheScaleCommand.php
@@ -13,7 +13,7 @@ class CacheScaleCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache:scale')

--- a/src/Commands/CacheShowCommand.php
+++ b/src/Commands/CacheShowCommand.php
@@ -13,7 +13,7 @@ class CacheShowCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache:show')

--- a/src/Commands/CacheTunnelCommand.php
+++ b/src/Commands/CacheTunnelCommand.php
@@ -12,7 +12,7 @@ class CacheTunnelCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cache:tunnel')

--- a/src/Commands/CertCommand.php
+++ b/src/Commands/CertCommand.php
@@ -14,7 +14,7 @@ class CertCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cert')

--- a/src/Commands/CertDeleteCommand.php
+++ b/src/Commands/CertDeleteCommand.php
@@ -13,7 +13,7 @@ class CertDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cert:delete')

--- a/src/Commands/CertListCommand.php
+++ b/src/Commands/CertListCommand.php
@@ -12,7 +12,7 @@ class CertListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cert:list')

--- a/src/Commands/CertValidateCommand.php
+++ b/src/Commands/CertValidateCommand.php
@@ -11,7 +11,7 @@ class CertValidateCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('cert:validate')

--- a/src/Commands/CommandAgainCommand.php
+++ b/src/Commands/CommandAgainCommand.php
@@ -13,7 +13,7 @@ class CommandAgainCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('command:again')

--- a/src/Commands/CommandCommand.php
+++ b/src/Commands/CommandCommand.php
@@ -15,7 +15,7 @@ class CommandCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('command')

--- a/src/Commands/CommandLogCommand.php
+++ b/src/Commands/CommandLogCommand.php
@@ -12,7 +12,7 @@ class CommandLogCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('command:log')

--- a/src/Commands/DatabaseCommand.php
+++ b/src/Commands/DatabaseCommand.php
@@ -14,7 +14,7 @@ class DatabaseCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database')

--- a/src/Commands/DatabaseDeleteCommand.php
+++ b/src/Commands/DatabaseDeleteCommand.php
@@ -13,7 +13,7 @@ class DatabaseDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:delete')

--- a/src/Commands/DatabaseDeleteProxyCommand.php
+++ b/src/Commands/DatabaseDeleteProxyCommand.php
@@ -12,7 +12,7 @@ class DatabaseDeleteProxyCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:delete-proxy')

--- a/src/Commands/DatabaseDropUserCommand.php
+++ b/src/Commands/DatabaseDropUserCommand.php
@@ -12,7 +12,7 @@ class DatabaseDropUserCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:drop-user')

--- a/src/Commands/DatabaseListCommand.php
+++ b/src/Commands/DatabaseListCommand.php
@@ -12,7 +12,7 @@ class DatabaseListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:list')

--- a/src/Commands/DatabaseMetricsCommand.php
+++ b/src/Commands/DatabaseMetricsCommand.php
@@ -12,7 +12,7 @@ class DatabaseMetricsCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:metrics')

--- a/src/Commands/DatabasePasswordCommand.php
+++ b/src/Commands/DatabasePasswordCommand.php
@@ -12,7 +12,7 @@ class DatabasePasswordCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:password')

--- a/src/Commands/DatabaseProxyCommand.php
+++ b/src/Commands/DatabaseProxyCommand.php
@@ -12,7 +12,7 @@ class DatabaseProxyCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:proxy')

--- a/src/Commands/DatabaseRestoreCommand.php
+++ b/src/Commands/DatabaseRestoreCommand.php
@@ -15,7 +15,7 @@ class DatabaseRestoreCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:restore')

--- a/src/Commands/DatabaseScaleCommand.php
+++ b/src/Commands/DatabaseScaleCommand.php
@@ -13,7 +13,7 @@ class DatabaseScaleCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:scale')

--- a/src/Commands/DatabaseShellCommand.php
+++ b/src/Commands/DatabaseShellCommand.php
@@ -12,7 +12,7 @@ class DatabaseShellCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:shell')

--- a/src/Commands/DatabaseShowCommand.php
+++ b/src/Commands/DatabaseShowCommand.php
@@ -13,7 +13,7 @@ class DatabaseShowCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:show')

--- a/src/Commands/DatabaseTunnelCommand.php
+++ b/src/Commands/DatabaseTunnelCommand.php
@@ -12,7 +12,7 @@ class DatabaseTunnelCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:tunnel')

--- a/src/Commands/DatabaseUpgradeCommand.php
+++ b/src/Commands/DatabaseUpgradeCommand.php
@@ -38,7 +38,7 @@ class DatabaseUpgradeCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:upgrade')

--- a/src/Commands/DatabaseUserCommand.php
+++ b/src/Commands/DatabaseUserCommand.php
@@ -12,7 +12,7 @@ class DatabaseUserCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:user')

--- a/src/Commands/DatabaseUsersCommand.php
+++ b/src/Commands/DatabaseUsersCommand.php
@@ -12,7 +12,7 @@ class DatabaseUsersCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('database:users')

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -24,7 +24,7 @@ class DeployCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('deploy')

--- a/src/Commands/DeployListCommand.php
+++ b/src/Commands/DeployListCommand.php
@@ -14,7 +14,7 @@ class DeployListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('deploy:list')

--- a/src/Commands/DownCommand.php
+++ b/src/Commands/DownCommand.php
@@ -16,7 +16,7 @@ class DownCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('down')

--- a/src/Commands/EnvCloneCommand.php
+++ b/src/Commands/EnvCloneCommand.php
@@ -17,7 +17,7 @@ class EnvCloneCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env:clone')

--- a/src/Commands/EnvCommand.php
+++ b/src/Commands/EnvCommand.php
@@ -17,7 +17,7 @@ class EnvCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env')

--- a/src/Commands/EnvDeleteCommand.php
+++ b/src/Commands/EnvDeleteCommand.php
@@ -15,7 +15,7 @@ class EnvDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env:delete')

--- a/src/Commands/EnvDescribeCommand.php
+++ b/src/Commands/EnvDescribeCommand.php
@@ -17,7 +17,7 @@ class EnvDescribeCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env:describe')

--- a/src/Commands/EnvListCommand.php
+++ b/src/Commands/EnvListCommand.php
@@ -12,7 +12,7 @@ class EnvListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env:list')

--- a/src/Commands/EnvPassportCommand.php
+++ b/src/Commands/EnvPassportCommand.php
@@ -14,7 +14,7 @@ class EnvPassportCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env:passport')

--- a/src/Commands/EnvPullCommand.php
+++ b/src/Commands/EnvPullCommand.php
@@ -13,7 +13,7 @@ class EnvPullCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env:pull')

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -14,7 +14,7 @@ class EnvPushCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('env:push')

--- a/src/Commands/FireCommand.php
+++ b/src/Commands/FireCommand.php
@@ -12,7 +12,7 @@ class FireCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('fire')

--- a/src/Commands/HookLogCommand.php
+++ b/src/Commands/HookLogCommand.php
@@ -13,7 +13,7 @@ class HookLogCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('hook:log')

--- a/src/Commands/HookOutputCommand.php
+++ b/src/Commands/HookOutputCommand.php
@@ -12,7 +12,7 @@ class HookOutputCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('hook:output')

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -16,7 +16,7 @@ class InitCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('init')

--- a/src/Commands/InvalidateAssetCacheCommand.php
+++ b/src/Commands/InvalidateAssetCacheCommand.php
@@ -13,7 +13,7 @@ class InvalidateAssetCacheCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('asset:invalidate-cache')

--- a/src/Commands/JumpCommand.php
+++ b/src/Commands/JumpCommand.php
@@ -12,7 +12,7 @@ class JumpCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('jump')

--- a/src/Commands/JumpDeleteCommand.php
+++ b/src/Commands/JumpDeleteCommand.php
@@ -12,7 +12,7 @@ class JumpDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('jump:delete')

--- a/src/Commands/JumpListCommand.php
+++ b/src/Commands/JumpListCommand.php
@@ -11,7 +11,7 @@ class JumpListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('jump:list')

--- a/src/Commands/LocalCommand.php
+++ b/src/Commands/LocalCommand.php
@@ -43,7 +43,7 @@ class LocalCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('local')

--- a/src/Commands/LoginCommand.php
+++ b/src/Commands/LoginCommand.php
@@ -15,7 +15,7 @@ class LoginCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('login')

--- a/src/Commands/MemberAddCommand.php
+++ b/src/Commands/MemberAddCommand.php
@@ -13,7 +13,7 @@ class MemberAddCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('member:add')

--- a/src/Commands/MemberListCommand.php
+++ b/src/Commands/MemberListCommand.php
@@ -11,7 +11,7 @@ class MemberListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('member:list')

--- a/src/Commands/MemberRemoveCommand.php
+++ b/src/Commands/MemberRemoveCommand.php
@@ -12,7 +12,7 @@ class MemberRemoveCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('member:remove')

--- a/src/Commands/MetricsCommand.php
+++ b/src/Commands/MetricsCommand.php
@@ -13,7 +13,7 @@ class MetricsCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('metrics')

--- a/src/Commands/NetworkCommand.php
+++ b/src/Commands/NetworkCommand.php
@@ -12,7 +12,7 @@ class NetworkCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('network')

--- a/src/Commands/NetworkDeleteCommand.php
+++ b/src/Commands/NetworkDeleteCommand.php
@@ -12,7 +12,7 @@ class NetworkDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('network:delete')

--- a/src/Commands/NetworkDeleteNatCommand.php
+++ b/src/Commands/NetworkDeleteNatCommand.php
@@ -12,7 +12,7 @@ class NetworkDeleteNatCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('network:delete-nat')

--- a/src/Commands/NetworkListCommand.php
+++ b/src/Commands/NetworkListCommand.php
@@ -12,7 +12,7 @@ class NetworkListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('network:list')

--- a/src/Commands/NetworkNatCommand.php
+++ b/src/Commands/NetworkNatCommand.php
@@ -12,7 +12,7 @@ class NetworkNatCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('network:nat')

--- a/src/Commands/NetworkShowCommand.php
+++ b/src/Commands/NetworkShowCommand.php
@@ -12,7 +12,7 @@ class NetworkShowCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('network:show')

--- a/src/Commands/OpenCommand.php
+++ b/src/Commands/OpenCommand.php
@@ -13,7 +13,7 @@ class OpenCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('open')

--- a/src/Commands/ProjectDeleteCommand.php
+++ b/src/Commands/ProjectDeleteCommand.php
@@ -13,7 +13,7 @@ class ProjectDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('project:delete')

--- a/src/Commands/ProjectDescribeCommand.php
+++ b/src/Commands/ProjectDescribeCommand.php
@@ -16,7 +16,7 @@ class ProjectDescribeCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('project:describe')

--- a/src/Commands/ProjectListCommand.php
+++ b/src/Commands/ProjectListCommand.php
@@ -11,7 +11,7 @@ class ProjectListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('project:list')

--- a/src/Commands/ProviderCommand.php
+++ b/src/Commands/ProviderCommand.php
@@ -13,7 +13,7 @@ class ProviderCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('provider')

--- a/src/Commands/ProviderDeleteCommand.php
+++ b/src/Commands/ProviderDeleteCommand.php
@@ -12,7 +12,7 @@ class ProviderDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('provider:delete')

--- a/src/Commands/ProviderListCommand.php
+++ b/src/Commands/ProviderListCommand.php
@@ -11,7 +11,7 @@ class ProviderListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('provider:list')

--- a/src/Commands/ProviderUpdateCommand.php
+++ b/src/Commands/ProviderUpdateCommand.php
@@ -14,7 +14,7 @@ class ProviderUpdateCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('provider:update')

--- a/src/Commands/RecordCommand.php
+++ b/src/Commands/RecordCommand.php
@@ -12,7 +12,7 @@ class RecordCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('record')

--- a/src/Commands/RecordDeleteCommand.php
+++ b/src/Commands/RecordDeleteCommand.php
@@ -13,7 +13,7 @@ class RecordDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('record:delete')

--- a/src/Commands/RecordListCommand.php
+++ b/src/Commands/RecordListCommand.php
@@ -13,7 +13,7 @@ class RecordListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('record:list')

--- a/src/Commands/RedeployCommand.php
+++ b/src/Commands/RedeployCommand.php
@@ -15,7 +15,7 @@ class RedeployCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('redeploy')

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -17,7 +17,7 @@ class RollbackCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('rollback')

--- a/src/Commands/SecretCommand.php
+++ b/src/Commands/SecretCommand.php
@@ -14,7 +14,7 @@ class SecretCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('secret')

--- a/src/Commands/SecretDeleteCommand.php
+++ b/src/Commands/SecretDeleteCommand.php
@@ -14,7 +14,7 @@ class SecretDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('secret:delete')

--- a/src/Commands/SecretListCommand.php
+++ b/src/Commands/SecretListCommand.php
@@ -13,7 +13,7 @@ class SecretListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('secret:list')

--- a/src/Commands/SecretPassportCommand.php
+++ b/src/Commands/SecretPassportCommand.php
@@ -13,7 +13,7 @@ class SecretPassportCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('secret:passport')

--- a/src/Commands/TailCommand.php
+++ b/src/Commands/TailCommand.php
@@ -38,7 +38,7 @@ class TailCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('tail')

--- a/src/Commands/TeamCommand.php
+++ b/src/Commands/TeamCommand.php
@@ -12,7 +12,7 @@ class TeamCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('team')

--- a/src/Commands/TeamCurrentCommand.php
+++ b/src/Commands/TeamCurrentCommand.php
@@ -11,7 +11,7 @@ class TeamCurrentCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('team:current')

--- a/src/Commands/TeamListCommand.php
+++ b/src/Commands/TeamListCommand.php
@@ -11,7 +11,7 @@ class TeamListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('team:list')

--- a/src/Commands/TeamSwitchCommand.php
+++ b/src/Commands/TeamSwitchCommand.php
@@ -13,7 +13,7 @@ class TeamSwitchCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('team:switch')

--- a/src/Commands/TestCommand.php
+++ b/src/Commands/TestCommand.php
@@ -25,7 +25,7 @@ class TestCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('test')

--- a/src/Commands/TinkerCommand.php
+++ b/src/Commands/TinkerCommand.php
@@ -13,7 +13,7 @@ class TinkerCommand extends CommandCommand
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('tinker')

--- a/src/Commands/UiCommand.php
+++ b/src/Commands/UiCommand.php
@@ -13,7 +13,7 @@ class UiCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('ui')

--- a/src/Commands/UpCommand.php
+++ b/src/Commands/UpCommand.php
@@ -15,7 +15,7 @@ class UpCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('up')

--- a/src/Commands/VanityDomainDeleteCommand.php
+++ b/src/Commands/VanityDomainDeleteCommand.php
@@ -14,7 +14,7 @@ class VanityDomainDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('vanity-domain:delete')

--- a/src/Commands/ZoneCommand.php
+++ b/src/Commands/ZoneCommand.php
@@ -12,7 +12,7 @@ class ZoneCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('zone')

--- a/src/Commands/ZoneDeleteCommand.php
+++ b/src/Commands/ZoneDeleteCommand.php
@@ -12,7 +12,7 @@ class ZoneDeleteCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('zone:delete')

--- a/src/Commands/ZoneListCommand.php
+++ b/src/Commands/ZoneListCommand.php
@@ -11,7 +11,7 @@ class ZoneListCommand extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('zone:list')

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Laravel\VaporCli\Tests;
+
+use Laravel\VaporCli\Application;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+
+class ApplicationTest extends TestCase
+{
+    public function test_add_registers_command()
+    {
+        $app = new Application('Vapor Test', '0.0.0');
+
+        $command = new Command('test:command');
+
+        $result = $app->add($command);
+
+        $this->assertSame($command, $result);
+        $this->assertTrue($app->has('test:command'));
+    }
+
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -19,5 +19,4 @@ class ApplicationTest extends TestCase
         $this->assertSame($command, $result);
         $this->assertTrue($app->has('test:command'));
     }
-
 }


### PR DESCRIPTION
V1.70 with symfony v8 support broke our GitHub actions CD pipeline. The Vapor-CLI is producing php errors. None of our Vapor projects were able to deploy without this fix.

We are running in our GitHub Action step: composer global require laravel/vapor-cli

This PR does:
Symfony Console v8 renamed add() to addCommand() and added void return types to configure(). This PR adds a compatibility shim for add() and updates all configure() signatures to include the required : void type.