### PR TITLE
Fix asset upload failures with guzzlehttp/guzzle 7.15+

### DIFF
--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -7,7 +7,6 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7\Request;
-use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use Laravel\VaporCli\ConsoleVaporClient;
 use Laravel\VaporCli\Exceptions\RequestFailedException;
@@ -103,7 +102,7 @@ class AwsStorageProvider
     public function executeStoreRequests($requests, $assetPath, $callback)
     {
         collect($requests)->chunk(10)->each(function ($chunkOfRequests) use ($assetPath, $callback) {
-            $requests = LazyCollection::make($chunkOfRequests)->map(function ($request) use ($assetPath) {
+            $requests = $chunkOfRequests->map(function ($request) use ($assetPath) {
                 $file = $assetPath.'/'.$request['path'];
                 $request['stream'] = fopen($file, 'r+');
 
@@ -126,18 +125,30 @@ class AwsStorageProvider
                 }
             };
 
-            (new Pool(new Client(['handler' => $this->retryHandler()]), $generator(), [
-                'concurrency' => 10,
-                'rejected' => function ($reason, $index) {
-                    throw new RequestFailedException($reason->getMessage(), $index);
-                },
-            ]))
-                ->promise()
-                ->wait();
+            $failure = null;
 
-            $requests->each(function ($request) {
-                fclose($request['stream']);
-            });
+            try {
+                (new Pool($this->client(), $generator(), [
+                    'concurrency' => 10,
+                    'rejected' => function ($reason, $index) use (&$failure) {
+                        if ($failure === null) {
+                            $failure = new RequestFailedException($reason->getMessage(), $index);
+                        }
+                    },
+                ]))
+                    ->promise()
+                    ->wait();
+            } finally {
+                $requests->each(function ($request) {
+                    if (is_resource($request['stream'])) {
+                        fclose($request['stream']);
+                    }
+                });
+            }
+
+            if ($failure !== null) {
+                throw $failure;
+            }
         });
     }
 
@@ -165,14 +176,32 @@ class AwsStorageProvider
             }
         };
 
-        (new Pool(new Client(['handler' => $this->retryHandler()]), $generator(), [
+        $failure = null;
+
+        (new Pool($this->client(), $generator(), [
             'concurrency' => 10,
-            'rejected' => function ($reason, $index) {
-                throw new RequestFailedException($reason->getMessage(), $index);
+            'rejected' => function ($reason, $index) use (&$failure) {
+                if ($failure === null) {
+                    $failure = new RequestFailedException($reason->getMessage(), $index);
+                }
             },
         ]))
             ->promise()
             ->wait();
+
+        if ($failure !== null) {
+            throw $failure;
+        }
+    }
+
+    /**
+     * Get a new HTTP client instance with the retry handler.
+     *
+     * @return \GuzzleHttp\Client
+     */
+    protected function client()
+    {
+        return new Client(['handler' => $this->retryHandler()]);
     }
 
     /**

--- a/src/Aws/AwsStorageProvider.php
+++ b/src/Aws/AwsStorageProvider.php
@@ -195,16 +195,6 @@ class AwsStorageProvider
     }
 
     /**
-     * Get a new HTTP client instance with the retry handler.
-     *
-     * @return \GuzzleHttp\Client
-     */
-    protected function client()
-    {
-        return new Client(['handler' => $this->retryHandler()]);
-    }
-
-    /**
      * Get a handler stack containing the retry middleware configuration.
      *
      * @return \GuzzleHttp\HandlerStack
@@ -230,5 +220,15 @@ class AwsStorageProvider
         }));
 
         return $stack;
+    }
+
+    /**
+     * Get a new HTTP client instance with the retry handler.
+     *
+     * @return \GuzzleHttp\Client
+     */
+    protected function client()
+    {
+        return new Client(['handler' => $this->retryHandler()]);
     }
 }

--- a/tests/AwsStorageProviderTest.php
+++ b/tests/AwsStorageProviderTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Laravel\VaporCli\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use GuzzleHttp\Psr7\Response;
+use Laravel\VaporCli\Aws\AwsStorageProvider;
+use Laravel\VaporCli\Exceptions\RequestFailedException;
+use PHPUnit\Framework\TestCase;
+
+class AwsStorageProviderTest extends TestCase
+{
+    protected $assetPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assetPath = sys_get_temp_dir().'/vapor-cli-test-'.uniqid();
+
+        mkdir($this->assetPath);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->assetPath.'/*') as $file) {
+            unlink($file);
+        }
+
+        rmdir($this->assetPath);
+
+        parent::tearDown();
+    }
+
+    public function test_copy_requests_execute_successfully()
+    {
+        $provider = new TestAwsStorageProvider(new MockHandler([
+            new Response(200),
+            new Response(200),
+        ]));
+
+        $handled = [];
+
+        $provider->executeCopyRequests([
+            ['url' => 'https://example.com/1', 'headers' => []],
+            ['url' => 'https://example.com/2', 'headers' => []],
+        ], function ($request) use (&$handled) {
+            $handled[] = $request['url'];
+        });
+
+        $this->assertSame(['https://example.com/1', 'https://example.com/2'], $handled);
+    }
+
+    public function test_copy_requests_throw_request_failed_exception_when_a_request_fails()
+    {
+        $mock = new MockHandler([
+            new ConnectException('Connection refused', new GuzzleRequest('PUT', 'https://example.com/1')),
+            new Response(200),
+        ]);
+
+        $provider = new TestAwsStorageProvider($mock);
+
+        $handled = [];
+
+        try {
+            $provider->executeCopyRequests([
+                ['url' => 'https://example.com/1', 'headers' => []],
+                ['url' => 'https://example.com/2', 'headers' => []],
+            ], function ($request) use (&$handled) {
+                $handled[] = $request['url'];
+            });
+
+            $this->fail('Expected RequestFailedException to be thrown.');
+        } catch (RequestFailedException $e) {
+            $this->assertStringContainsString('Connection refused', $e->getMessage());
+            $this->assertSame(0, $e->getIndex());
+        }
+
+        // The pool should settle cleanly, meaning the remaining requests
+        // were still executed and the mock queue was fully drained...
+        $this->assertCount(2, $handled);
+        $this->assertSame(0, $mock->count());
+    }
+
+    public function test_store_requests_execute_successfully()
+    {
+        file_put_contents($this->assetPath.'/a.txt', 'a');
+        file_put_contents($this->assetPath.'/b.txt', 'b');
+
+        $provider = new TestAwsStorageProvider(new MockHandler([
+            new Response(200),
+            new Response(200),
+        ]));
+
+        $handled = [];
+
+        $provider->executeStoreRequests([
+            ['path' => 'a.txt', 'url' => 'https://example.com/a', 'headers' => []],
+            ['path' => 'b.txt', 'url' => 'https://example.com/b', 'headers' => []],
+        ], $this->assetPath, function ($request) use (&$handled) {
+            $handled[] = $request['path'];
+        });
+
+        $this->assertSame(['a.txt', 'b.txt'], $handled);
+    }
+
+    public function test_store_requests_throw_request_failed_exception_and_close_streams_on_failure()
+    {
+        file_put_contents($this->assetPath.'/a.txt', 'a');
+        file_put_contents($this->assetPath.'/b.txt', 'b');
+
+        $provider = new TestAwsStorageProvider(new MockHandler([
+            new ConnectException('Connection refused', new GuzzleRequest('PUT', 'https://example.com/a')),
+            new Response(200),
+        ]));
+
+        $streams = [];
+
+        try {
+            $provider->executeStoreRequests([
+                ['path' => 'a.txt', 'url' => 'https://example.com/a', 'headers' => []],
+                ['path' => 'b.txt', 'url' => 'https://example.com/b', 'headers' => []],
+            ], $this->assetPath, function ($request) use (&$streams) {
+                $streams[] = $request['stream'];
+            });
+
+            $this->fail('Expected RequestFailedException to be thrown.');
+        } catch (RequestFailedException $e) {
+            $this->assertStringContainsString('Connection refused', $e->getMessage());
+        }
+
+        // All opened file streams should have been closed, even on failure...
+        $this->assertCount(2, $streams);
+
+        foreach ($streams as $stream) {
+            $this->assertFalse(is_resource($stream));
+        }
+    }
+}
+
+class TestAwsStorageProvider extends AwsStorageProvider
+{
+    /**
+     * The mock handler stack.
+     *
+     * @var \GuzzleHttp\HandlerStack
+     */
+    protected $handlerStack;
+
+    /**
+     * Create a new test storage provider instance.
+     *
+     * @param  \GuzzleHttp\Handler\MockHandler  $mock
+     * @return void
+     */
+    public function __construct(MockHandler $mock)
+    {
+        $this->handlerStack = HandlerStack::create($mock);
+    }
+
+    /**
+     * Get a new HTTP client instance with the mock handler.
+     *
+     * @return \GuzzleHttp\Client
+     */
+    protected function client()
+    {
+        return new Client(['handler' => $this->handlerStack]);
+    }
+}


### PR DESCRIPTION
Throwing from within a Pool 'rejected' callback leaves Guzzle's EachPromise in an inconsistent state, which Guzzle 7.15's scoped cURL multi handler waits no longer tolerate — wait() falls back to rejecting with 'Invoking the wait callback did not resolve the promise'.

Capture the first failure in the callback instead, let the pool settle cleanly, and throw the RequestFailedException after wait() returns. Also close store request file streams in a finally block, open each stream only once (the lazy map previously ran fopen twice per file), and add a client() factory seam so the failure paths can be tested against a mock handler.