### PR TITLE
Allow guzzlehttp/guzzle ^8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "ext-zip": "*",
-        "guzzlehttp/guzzle": "^6.3|^7.0",
+        "guzzlehttp/guzzle": "^6.3|^7.0|^8.0",
         "illuminate/container": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/filesystem": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",


### PR DESCRIPTION
Guzzle 8 has been out since May and is currently blocked for projects (and global Composer installs) that have the Vapor CLI alongside packages already allowing Guzzle 8. This widens the constraint so Composer can resolve either major. Related: laravel/valet#1563 does the same for Valet.

## Summary

- Adds `^8.0` to the `guzzlehttp/guzzle` constraint, keeping `^6.3|^7.0` intact. On PHP 7.2/7.3 Composer keeps resolving Guzzle 6/7, so no platform change is needed.
- The CLI's Guzzle usage is untouched by the v8 breaking changes. `ConsoleVaporClient` and `AwsStorageProvider` use `(new Client)->request(...)` with the `base_uri`, `json`, `headers`, `body`, and `progress` options, all unchanged in v8. `Pool`, `HandlerStack::create()`, and `Middleware::retry()` used for asset uploads still exist, and passing `handler` in the client constructor remains supported (v8 only removed the per-request `handler` option). `ClientException` used for the 429 retry handling also remains.
- No transitive blockers: `aws/aws-sdk-php` allows Guzzle `^8.0` as of 3.393.4.

## Test plan

- `composer update` resolves `guzzlehttp/guzzle` to 8.1.0 alongside `aws/aws-sdk-php` 3.393.4.
- Full test suite passes with Guzzle 8 installed: 56 tests, 63 assertions.
- CI is green across the full matrix (PHP 8.1-8.5 x Laravel 10-13), including Static Analysis and StyleCI.